### PR TITLE
Add --no-write-to-file and --example-workers 0 to linter doccmd hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,8 +113,8 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uvx --python=3.13 doccmd --language=shell --language=console --command="shellcheck
-          --shell=bash"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=shell
+          --language=console --command="shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -149,7 +149,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uvx --python=3.13 doccmd --language=python --command="mypy"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="mypy"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -174,7 +175,8 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uvx --python=3.13 doccmd --language=python --command="pyright"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -190,7 +192,8 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uvx --python=3.13 doccmd --language=python --command="vulture"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -223,7 +226,8 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uvx --python=3.13 doccmd --language=python --command="pylint"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -289,7 +293,8 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uvx --python=3.13 doccmd --language=python --command="interrogate"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
## Summary
- Add `--no-write-to-file` and `--example-workers 0` to all linter doccmd hooks

## Benefits
- `--no-write-to-file`: Ensures linter hooks only read and analyze code without modifying files (correct behavior for linters)
- `--example-workers 0`: Enables parallel processing of code blocks in documentation, auto-detecting optimal worker count based on CPU cores
- Significantly speeds up linter hooks (mypy, pyright, shellcheck, vulture, etc.)

## Details
These flags enable doccmd to process multiple code blocks concurrently when running read-only linters. The `--no-write-to-file` flag is essential for linters as they should only emit diagnostics, not modify files. The `--example-workers 0` flag then safely enables parallel execution for better performance.

## Hooks Updated
- shellcheck-docs
- mypy-docs
- pyright-docs
- vulture-docs
- pylint-docs
- interrogate-docs (sybil-extras only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)