### PR TITLE
Share some more code between group parsers

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -6,6 +6,7 @@ formatter
 formatters
 hardcode
 iff
+lexeme
 linter
 namespace
 ons

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -4,11 +4,12 @@ Shared utilities for grouping parsers.
 
 from collections.abc import Sequence
 
-from sybil import Example
+from sybil import Example, Region
 from sybil.region import Lexeme
+from sybil.typing import Evaluator
 
 
-def combine_examples_text(
+def _combine_examples_text(
     examples: Sequence[Example],
     *,
     pad_groups: bool,
@@ -47,4 +48,66 @@ def combine_examples_text(
         text=result.text,
         offset=result.offset,
         line_offset=result.line_offset,
+    )
+
+
+def has_source(example: Example) -> bool:
+    """Check if an example has a source lexeme.
+
+    Args:
+        example: The example to check.
+
+    Returns:
+        True if the example has a source lexeme.
+    """
+    return "source" in example.region.lexemes
+
+
+def create_combined_region(
+    examples: Sequence[Example],
+    *,
+    evaluator: Evaluator,
+    pad_groups: bool,
+) -> Region:
+    """Create a combined region from multiple examples.
+
+    Args:
+        examples: The examples to combine.
+        evaluator: The evaluator to use for the combined region.
+        pad_groups: Whether to pad groups with empty lines.
+
+    Returns:
+        The combined region.
+    """
+    return Region(
+        start=examples[0].region.start,
+        end=examples[-1].region.end,
+        parsed=_combine_examples_text(
+            examples=examples,
+            pad_groups=pad_groups,
+        ),
+        evaluator=evaluator,
+        lexemes=examples[0].region.lexemes,
+    )
+
+
+def create_combined_example(
+    examples: Sequence[Example],
+    region: Region,
+) -> Example:
+    """Create a combined example from multiple examples.
+
+    Args:
+        examples: The examples that were combined.
+        region: The combined region.
+
+    Returns:
+        The combined example.
+    """
+    return Example(
+        document=examples[0].document,
+        line=examples[0].line,
+        column=examples[0].column,
+        region=region,
+        namespace=examples[0].namespace,
     )

--- a/src/sybil_extras/parsers/abstract/group_all.py
+++ b/src/sybil_extras/parsers/abstract/group_all.py
@@ -9,7 +9,11 @@ from sybil import Document, Example, Region
 from sybil.example import NotEvaluated
 from sybil.typing import Evaluator
 
-from ._grouping_utils import combine_examples_text
+from ._grouping_utils import (
+    create_combined_example,
+    create_combined_region,
+    has_source,
+)
 
 
 class _GroupAllState:
@@ -54,8 +58,7 @@ class _GroupAllEvaluator:
         Collect an example to be grouped.
         """
         state = self._document_state[example.document]
-        has_source = "source" in example.region.lexemes
-        if has_source:
+        if has_source(example=example):
             state.examples.append(example)
             return
 
@@ -73,22 +76,14 @@ class _GroupAllEvaluator:
             del self._document_state[example.document]
             return
 
-        region = Region(
-            start=state.examples[0].region.start,
-            end=state.examples[-1].region.end,
-            parsed=combine_examples_text(
-                examples=state.examples,
-                pad_groups=self._pad_groups,
-            ),
+        region = create_combined_region(
+            examples=state.examples,
             evaluator=self._evaluator,
-            lexemes=example.region.lexemes,
+            pad_groups=self._pad_groups,
         )
-        new_example = Example(
-            document=example.document,
-            line=state.examples[0].line,
-            column=state.examples[0].column,
+        new_example = create_combined_example(
+            examples=state.examples,
             region=region,
-            namespace=example.namespace,
         )
         self._evaluator(new_example)
 

--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -11,7 +11,11 @@ from sybil.example import NotEvaluated
 from sybil.parsers.abstract.lexers import LexerCollection
 from sybil.typing import Evaluator, Lexer
 
-from ._grouping_utils import combine_examples_text
+from ._grouping_utils import (
+    create_combined_example,
+    create_combined_region,
+    has_source,
+)
 
 
 class _GroupState:
@@ -81,22 +85,14 @@ class _Grouper:
             raise ValueError(msg)
 
         if state.examples:
-            region = Region(
-                start=state.examples[0].region.start,
-                end=state.examples[-1].region.end,
-                parsed=combine_examples_text(
-                    examples=state.examples,
-                    pad_groups=self._pad_groups,
-                ),
+            region = create_combined_region(
+                examples=state.examples,
                 evaluator=self._evaluator,
-                lexemes=example.region.lexemes,
+                pad_groups=self._pad_groups,
             )
-            new_example = Example(
-                document=example.document,
-                line=state.examples[0].line,
-                column=state.examples[0].column,
+            new_example = create_combined_example(
+                examples=state.examples,
                 region=region,
-                namespace=example.namespace,
             )
             self._evaluator(new_example)
 
@@ -110,9 +106,7 @@ class _Grouper:
         """
         state = self._document_state[example.document]
 
-        has_source = "source" in example.region.lexemes
-
-        if has_source:
+        if has_source(example=example):
             state.examples = [*state.examples, example]
             return
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extracts shared grouping helpers and refactors group parsers to use them; updates spelling dictionary.
> 
> - **Parsers (abstract utils)**:
>   - Add `has_source()`, `create_combined_region()`, and `create_combined_example()` in `src/sybil_extras/parsers/abstract/_grouping_utils.py`.
>   - Rename `combine_examples_text` to private `_combine_examples_text` and use it in helpers.
> - **Group Parsers**:
>   - `group_all.py`: replace inline source checks and region/example construction with `has_source`, `create_combined_region`, and `create_combined_example`.
>   - `grouped_source.py`: same refactor for grouping start/end handling and example collection.
> - **Spelling**:
>   - Add `lexeme` to `spelling_private_dict.txt`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efd6be926e12fcaf2dd49bad0aff2b1fe77f5d52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->