### PR TITLE
Use beartype in more places

### DIFF
--- a/src/sybil_extras/evaluators/no_op.py
+++ b/src/sybil_extras/evaluators/no_op.py
@@ -2,9 +2,11 @@
 No-op Evaluator.
 """
 
+from beartype import beartype
 from sybil.example import Example
 
 
+@beartype
 class NoOpEvaluator:
     """An evaluator that does nothing.
 

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -4,11 +4,13 @@ Shared utilities for grouping parsers.
 
 from collections.abc import Sequence
 
+from beartype import beartype
 from sybil import Example, Region
 from sybil.region import Lexeme
 from sybil.typing import Evaluator
 
 
+@beartype
 def _combine_examples_text(
     examples: Sequence[Example],
     *,
@@ -51,6 +53,7 @@ def _combine_examples_text(
     )
 
 
+@beartype
 def has_source(example: Example) -> bool:
     """Check if an example has a source lexeme.
 
@@ -63,6 +66,7 @@ def has_source(example: Example) -> bool:
     return "source" in example.region.lexemes
 
 
+@beartype
 def create_combined_region(
     examples: Sequence[Example],
     *,
@@ -91,6 +95,7 @@ def create_combined_region(
     )
 
 
+@beartype
 def create_combined_example(
     examples: Sequence[Example],
     region: Region,

--- a/src/sybil_extras/parsers/abstract/group_all.py
+++ b/src/sybil_extras/parsers/abstract/group_all.py
@@ -5,6 +5,7 @@ Abstract parser that groups all code blocks in a document.
 from collections import defaultdict
 from collections.abc import Iterable
 
+from beartype import beartype
 from sybil import Document, Example, Region
 from sybil.example import NotEvaluated
 from sybil.typing import Evaluator
@@ -16,6 +17,7 @@ from ._grouping_utils import (
 )
 
 
+@beartype
 class _GroupAllState:
     """
     State for grouping all examples in a document.
@@ -28,6 +30,7 @@ class _GroupAllState:
         self.examples: list[Example] = []
 
 
+@beartype
 class _GroupAllEvaluator:
     """
     Evaluator that collects all examples and evaluates them as one.
@@ -109,6 +112,7 @@ class _GroupAllEvaluator:
     _caller = __call__
 
 
+@beartype
 class AbstractGroupAllParser:
     """
     An abstract parser that groups all code blocks in a document without

--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from typing import Literal
 
+from beartype import beartype
 from sybil import Document, Example, Region
 from sybil.example import NotEvaluated
 from sybil.parsers.abstract.lexers import LexerCollection
@@ -18,6 +19,7 @@ from ._grouping_utils import (
 )
 
 
+@beartype
 class _GroupState:
     """
     Group state.
@@ -31,6 +33,7 @@ class _GroupState:
         self.examples: Sequence[Example] = []
 
 
+@beartype
 class _Grouper:
     """
     Group blocks of source code.
@@ -129,6 +132,7 @@ class _Grouper:
     _caller = __call__
 
 
+@beartype
 class AbstractGroupedSourceParser:
     """
     An abstract parser for grouping blocks of source code.

--- a/src/sybil_extras/parsers/markdown/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/markdown/custom_directive_skip.py
@@ -5,12 +5,14 @@ A custom directive skip parser for Markdown.
 import re
 from collections.abc import Iterable
 
+from beartype import beartype
 from sybil import Document, Region
 from sybil.evaluators.skip import Skipper
 from sybil.parsers.abstract import AbstractSkipParser
 from sybil.parsers.markdown.lexers import DirectiveInHTMLCommentLexer
 
 
+@beartype
 class CustomDirectiveSkipParser:
     """
     A custom directive skip parser for Markdown.

--- a/src/sybil_extras/parsers/markdown/group_all.py
+++ b/src/sybil_extras/parsers/markdown/group_all.py
@@ -2,9 +2,12 @@
 A parser that groups all code blocks in a Markdown document.
 """
 
+from beartype import beartype
+
 from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 
 
+@beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
     A parser that groups all code blocks in a document without markup.

--- a/src/sybil_extras/parsers/markdown/grouped_source.py
+++ b/src/sybil_extras/parsers/markdown/grouped_source.py
@@ -4,6 +4,7 @@ A group parser for Markdown.
 
 import re
 
+from beartype import beartype
 from sybil.parsers.markdown.lexers import DirectiveInHTMLCommentLexer
 from sybil.typing import Evaluator
 
@@ -12,6 +13,7 @@ from sybil_extras.parsers.abstract.grouped_source import (
 )
 
 
+@beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
     """
     A code block group parser for Markdown.

--- a/src/sybil_extras/parsers/myst/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/myst/custom_directive_skip.py
@@ -5,6 +5,7 @@ A custom directive skip parser for MyST.
 import re
 from collections.abc import Iterable
 
+from beartype import beartype
 from sybil import Document, Region
 from sybil.evaluators.skip import Skipper
 from sybil.parsers.abstract import AbstractSkipParser
@@ -14,6 +15,7 @@ from sybil.parsers.myst.lexers import (
 )
 
 
+@beartype
 class CustomDirectiveSkipParser:
     """
     A custom directive skip parser for MyST.

--- a/src/sybil_extras/parsers/myst/group_all.py
+++ b/src/sybil_extras/parsers/myst/group_all.py
@@ -2,9 +2,12 @@
 A parser that groups all code blocks in a MyST document.
 """
 
+from beartype import beartype
+
 from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 
 
+@beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
     A parser that groups all code blocks in a document without markup.

--- a/src/sybil_extras/parsers/myst/grouped_source.py
+++ b/src/sybil_extras/parsers/myst/grouped_source.py
@@ -4,6 +4,7 @@ A group parser for MyST.
 
 import re
 
+from beartype import beartype
 from sybil.parsers.markdown.lexers import DirectiveInHTMLCommentLexer
 from sybil.parsers.myst.lexers import (
     DirectiveInPercentCommentLexer,
@@ -15,6 +16,7 @@ from sybil_extras.parsers.abstract.grouped_source import (
 )
 
 
+@beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
     """
     A code block group parser for MyST.

--- a/src/sybil_extras/parsers/myst/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/myst/sphinx_jinja2.py
@@ -5,12 +5,14 @@ A parser for sphinx-jinja2 blocks in MyST.
 import re
 from collections.abc import Iterable
 
+from beartype import beartype
 from sybil import Document, Region
 from sybil.parsers.abstract.lexers import LexerCollection
 from sybil.parsers.myst.lexers import DirectiveLexer
 from sybil.typing import Evaluator
 
 
+@beartype
 class SphinxJinja2Parser:
     """
     A parser for sphinx-jinja2 blocks in MyST.

--- a/src/sybil_extras/parsers/rest/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/rest/custom_directive_skip.py
@@ -5,12 +5,14 @@ A custom directive skip parser for reST.
 import re
 from collections.abc import Iterable
 
+from beartype import beartype
 from sybil import Document, Region
 from sybil.evaluators.skip import Skipper
 from sybil.parsers.abstract import AbstractSkipParser
 from sybil.parsers.rest.lexers import DirectiveInCommentLexer
 
 
+@beartype
 class CustomDirectiveSkipParser:
     """
     A custom directive skip parser for reST.

--- a/src/sybil_extras/parsers/rest/group_all.py
+++ b/src/sybil_extras/parsers/rest/group_all.py
@@ -2,9 +2,12 @@
 A parser that groups all code blocks in a reStructuredText document.
 """
 
+from beartype import beartype
+
 from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 
 
+@beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
     A parser that groups all code blocks in a document without markup.

--- a/src/sybil_extras/parsers/rest/grouped_source.py
+++ b/src/sybil_extras/parsers/rest/grouped_source.py
@@ -4,6 +4,7 @@ A group parser for reST.
 
 import re
 
+from beartype import beartype
 from sybil.parsers.rest.lexers import DirectiveInCommentLexer
 from sybil.typing import Evaluator
 
@@ -12,6 +13,7 @@ from sybil_extras.parsers.abstract.grouped_source import (
 )
 
 
+@beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
     """
     A code block group parser for reST.

--- a/src/sybil_extras/parsers/rest/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/rest/sphinx_jinja2.py
@@ -5,12 +5,14 @@ A parser for Sphinx jinja2 blocks in reST.
 import re
 from collections.abc import Iterable
 
+from beartype import beartype
 from sybil import Document, Region
 from sybil.parsers.abstract.lexers import LexerCollection
 from sybil.parsers.rest.lexers import DirectiveLexer
 from sybil.typing import Evaluator
 
 
+@beartype
 class SphinxJinja2Parser:
     """
     A parser for Sphinx jinja2 blocks in reST.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add beartype runtime type checking via @beartype to evaluators, grouping utilities, and Markdown/MyST/reST parsers.
> 
> - **Typing/Runtime checks**
>   - Add `from beartype import beartype` and decorate classes/functions with `@beartype` across:
>     - `evaluators/no_op.py` (`NoOpEvaluator`)
>     - Abstract parsers: `parsers/abstract/_grouping_utils.py` (helpers), `group_all.py` (state/evaluator/parser), `grouped_source.py` (state/grouper/parser)
>     - Format-specific parsers:
>       - Markdown: `custom_directive_skip.py`, `group_all.py`, `grouped_source.py`
>       - MyST: `custom_directive_skip.py`, `group_all.py`, `grouped_source.py`, `sphinx_jinja2.py`
>       - reST: `custom_directive_skip.py`, `group_all.py`, `grouped_source.py`, `sphinx_jinja2.py`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit de079e3bc8613023ebc5cc7f7a05846d8abaa164. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->