### PR TITLE
Add .prettierrc configuration

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "overrides": [
+    {
+      "files": ["*.yaml", "*.yml"],
+      "options": {
+        "singleQuote": true
+      }
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,7 @@ make-summary-multi-line = true
 
 ignore = [
     ".checkmake-config.ini",
+    ".prettierrc",
     ".yamlfmt",
     "*.enc",
     ".git_archival.txt",


### PR DESCRIPTION
Add Prettier configuration file with YAML single quote override from click-compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> .prettierrc added to enforce single quotes in YAML; `pyproject.toml` updated to ignore it in check-manifest.
> 
> - **Config**:
>   - Add `.prettierrc` with YAML/YML override (`singleQuote: true`).
>   - Update `pyproject.toml` (`[tool.check-manifest].ignore`) to include `.prettierrc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01a74d539e324c6e479dd7c44408ce2da529b4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->