### PR TITLE
Make it clearer in pytest output which language is being tested

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,10 @@ import pytest
 
 from sybil_extras.languages import ALL_LANGUAGES, MarkupLanguage
 
+LANGUAGE_IDS = tuple(language.name for language in ALL_LANGUAGES)
 
-@pytest.fixture(name="language", params=ALL_LANGUAGES)
+
+@pytest.fixture(name="language", params=ALL_LANGUAGES, ids=LANGUAGE_IDS)
 def fixture_language(request: pytest.FixtureRequest) -> MarkupLanguage:
     """
     Provide each supported markup language.
@@ -19,7 +21,11 @@ def fixture_language(request: pytest.FixtureRequest) -> MarkupLanguage:
     return language
 
 
-@pytest.fixture(name="markup_language", params=ALL_LANGUAGES)
+@pytest.fixture(
+    name="markup_language",
+    params=ALL_LANGUAGES,
+    ids=LANGUAGE_IDS,
+)
 def fixture_markup_language(request: pytest.FixtureRequest) -> MarkupLanguage:
     """
     Provide each supported markup language.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add `ids` to parametrized language fixtures so pytest shows readable language names in output.
> 
> - **Tests**:
>   - Define `LANGUAGE_IDS` from `ALL_LANGUAGES` in `tests/conftest.py`.
>   - Update fixtures `language` and `markup_language` to use `ids=LANGUAGE_IDS` for clearer parametrized test names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ce33f6ac98667de926736df65ef08f4df4bd167. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->