### PR TITLE
Add ungrouped_evaluator option to attribute grouped source parser

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -329,6 +329,7 @@ This is useful for MDX documentation where code blocks with the same group attri
     from sybil import Sybil
     from sybil.example import Example
 
+    from sybil_extras.evaluators.no_op import NoOpEvaluator
     from sybil_extras.parsers.mdx.attribute_grouped_source import (
         AttributeGroupedSourceParser,
     )
@@ -353,6 +354,9 @@ This is useful for MDX documentation where code blocks with the same group attri
         # However, this is detrimental to commands that expect the file
         # to not have a bunch of newlines in it, such as formatters.
         pad_groups=True,
+        # The evaluator to use for code blocks that don't have the
+        # grouping attribute.
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -388,8 +392,8 @@ An MDX example:
 In this example, the first two code blocks will be combined and evaluated as one block,
 while the third block (with ``group="example2"``) will be evaluated separately.
 
-Only code blocks with the ``group`` attribute (or custom attribute name) will be grouped.
-Code blocks without the attribute are ignored by this parser.
+Code blocks with the ``group`` attribute (or custom attribute name) will be grouped.
+Code blocks without the attribute are evaluated with the ``ungrouped_evaluator``.
 
 SphinxJinja2Parser
 ^^^^^^^^^^^^^^^^^^

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -21,4 +21,5 @@ pytest
 rst
 stderr
 stdout
+ungrouped
 whitespace

--- a/src/sybil_extras/parsers/abstract/attribute_grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/attribute_grouped_source.py
@@ -37,7 +37,7 @@ class AbstractAttributeGroupedSourceParser:
         evaluator: Evaluator,
         attribute_name: str,
         pad_groups: bool,
-        ungrouped_evaluator: Evaluator | None = None,
+        ungrouped_evaluator: Evaluator,
     ) -> None:
         """
         Args:
@@ -50,8 +50,7 @@ class AbstractAttributeGroupedSourceParser:
                 However, this is detrimental to commands that expect the file
                 to not have a bunch of newlines in it, such as formatters.
             ungrouped_evaluator: The evaluator to use for code blocks that
-                don't have the grouping attribute. If not provided, ungrouped
-                blocks are ignored.
+                don't have the grouping attribute.
         """
         self._code_block_parser = code_block_parser
         self._evaluator = evaluator
@@ -73,16 +72,15 @@ class AbstractAttributeGroupedSourceParser:
             attributes = region.lexemes.get("attributes", {})
             group_name: str | None = attributes.get(self._attribute_name)
             if not group_name:
-                if self._ungrouped_evaluator is not None:
-                    ungrouped_regions.append(
-                        Region(
-                            start=region.start,
-                            end=region.end,
-                            parsed=region.parsed,
-                            evaluator=self._ungrouped_evaluator,
-                            lexemes=region.lexemes,
-                        )
+                ungrouped_regions.append(
+                    Region(
+                        start=region.start,
+                        end=region.end,
+                        parsed=region.parsed,
+                        evaluator=self._ungrouped_evaluator,
+                        lexemes=region.lexemes,
                     )
+                )
                 continue
 
             # Create an example from the region to collect metadata.

--- a/tests/parsers/test_attribute_grouped_source.py
+++ b/tests/parsers/test_attribute_grouped_source.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from sybil import Sybil
 
 from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
+from sybil_extras.evaluators.no_op import NoOpEvaluator
 from sybil_extras.parsers.mdx.attribute_grouped_source import (
     AttributeGroupedSourceParser,
 )
@@ -41,6 +42,7 @@ def test_attribute_group_single_group(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="group",
         pad_groups=True,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -91,6 +93,7 @@ def test_attribute_group_multiple_groups(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="group",
         pad_groups=True,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -133,6 +136,7 @@ def test_attribute_group_no_group_attribute(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="group",
         pad_groups=True,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -169,6 +173,7 @@ def test_attribute_group_custom_attribute_name(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="mygroup",
         pad_groups=True,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -206,6 +211,7 @@ def test_attribute_group_with_other_attributes(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="group",
         pad_groups=True,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -247,6 +253,7 @@ def test_attribute_group_pad_groups_false(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="group",
         pad_groups=False,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])
@@ -296,6 +303,7 @@ def test_attribute_group_interleaved_groups(tmp_path: Path) -> None:
         evaluator=evaluator,
         attribute_name="group",
         pad_groups=False,
+        ungrouped_evaluator=NoOpEvaluator(),
     )
 
     sybil = Sybil(parsers=[group_parser])


### PR DESCRIPTION
Add an optional `ungrouped_evaluator` parameter to `AbstractAttributeGroupedSourceParser` that allows handling code blocks that don't have the grouping attribute.

When provided, ungrouped blocks are evaluated with the ungrouped evaluator instead of being ignored. This is useful when you want to process all code blocks in a document but still group certain blocks together.

## Changes
- Added optional `ungrouped_evaluator` parameter (defaults to `None` for backwards compatibility)
- Ungrouped regions are collected and yielded after grouped regions
- Added test `test_attribute_group_ungrouped_evaluator` to verify the feature

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for evaluating code blocks without a grouping attribute via a new `ungrouped_evaluator` in `AbstractAttributeGroupedSourceParser`.
> 
> - **Parsers**:
>   - `src/sybil_extras/parsers/abstract/attribute_grouped_source.py`:
>     - Add `ungrouped_evaluator` parameter and store as `_ungrouped_evaluator`.
>     - Collect ungrouped regions and yield them after grouped regions, evaluated with `ungrouped_evaluator`.
> - **Docs**:
>   - `README.rst`:
>     - Document `ungrouped_evaluator` in the `AttributeGroupedSourceParser` example and behavior notes.
> - **Tests**:
>   - `tests/parsers/test_attribute_grouped_source.py`:
>     - Update existing tests to pass `ungrouped_evaluator`.
>     - Add `test_attribute_group_ungrouped_evaluator` to verify ungrouped blocks are evaluated separately.
> - **Misc**:
>   - `spelling_private_dict.txt`: add `ungrouped`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97cb99c49b68d986f4ebc081616ebd38e4cf5871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->