### PR TITLE
Improve line start calculation

### DIFF
--- a/src/sybil_extras/parsers/abstract/attribute_grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/attribute_grouped_source.py
@@ -91,7 +91,9 @@ class AbstractAttributeGroupedSourceParser:
             # requires line/column numbers. We calculate these the same way
             # Sybil does internally in Document.line_column().
             source = region.lexemes["source"]
-            line = document.text.count("\n", 0, region.start) + 1
+            # Calculate line based on where the source content actually starts
+            source_start = region.start + source.offset
+            line = document.text.count("\n", 0, source_start) + 1
             column = region.start - document.text.rfind("\n", 0, region.start)
             example = Example(
                 document=document,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust line calculation to use the source lexeme’s start offset so example line numbers align with actual code content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6715b32ab7e82848ba3cdef638793f2c2366df51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->