### PR TITLE
Add validation for gha-find-replace actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,7 @@ jobs:
           echo "underline=${underline}" >> "$GITHUB_OUTPUT"
 
       - name: Update changelog
+        id: update_changelog
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
@@ -63,6 +64,12 @@ jobs:
           include: CHANGELOG.rst
           regex: false
 
+      - name: Check Update changelog was modified
+        run: |
+          if [ "${{ steps.update_changelog.outputs.modifiedFiles }}" = "0" ]; then
+            echo "Error: No files were modified when updating changelog"
+            exit 1
+          fi
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
         with:


### PR DESCRIPTION
## Summary
- Add validation for gha-find-replace actions
- Fail the workflow if no files are modified during file updates
- This prevents silent failures in the release process

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add validation in the release workflow to fail if the changelog find/replace modifies no files, by giving the step an id and checking its `modifiedFiles` output.
> 
> - **CI/Release Workflow (`.github/workflows/release.yml`)**:
>   - Add `id: update_changelog` to `Update changelog` step to expose outputs.
>   - New verification step: checks `steps.update_changelog.outputs.modifiedFiles` and fails the job if it's `0` (ensures changelog update actually modified files).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47c7c4d41a9821116e6b1e0b6a45c4b1dd04b192. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->