### PR TITLE
Norg: Fix whitespace after end of code block

### DIFF
--- a/src/sybil_extras/parsers/norg/codeblock.py
+++ b/src/sybil_extras/parsers/norg/codeblock.py
@@ -47,8 +47,9 @@ class NorgVerbatimRangedTagLexer:
         )
         # Pattern to match closing tag: @end
         # Must be at start of line (with optional leading whitespace)
+        # Allow trailing whitespace after @end for consistency with opening
         self._closing_pattern = re.compile(
-            pattern=r"^\s*@end$",
+            pattern=r"^\s*@end[^\S\n]*$",
             flags=re.MULTILINE,
         )
         self._mapping = mapping

--- a/tests/parsers/norg/test_codeblock.py
+++ b/tests/parsers/norg/test_codeblock.py
@@ -198,3 +198,14 @@ def test_nested_code_markers_in_content() -> None:
     )
 
     assert region.parsed == '# This is @code\nx = "@end"\n'
+
+
+def test_trailing_whitespace_after_end() -> None:
+    """
+    A code block with trailing whitespace after @end is parsed.
+    """
+    # Use a raw string to preserve the trailing spaces after @end
+    text = "@code python\nx = 1\n@end   \n"
+    (region,) = _parse(text=text)
+
+    assert region.parsed == "x = 1\n"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relax closing tag regex to accept trailing whitespace after `@end` in Norg code blocks and add a test to cover it.
> 
> - **Parser (Norg code blocks)**
>   - Update closing tag regex in `src/sybil_extras/parsers/norg/codeblock.py` to accept trailing whitespace after `@end`.
> - **Tests**
>   - Add `test_trailing_whitespace_after_end` in `tests/parsers/norg/test_codeblock.py` verifying parsing with spaces after `@end`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 88de11704c63fa73f285a0e22d5f680c04f92fbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->