### PR TITLE
Bump beartype to 0.22.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.19.0",
+    "beartype>=0.22.9",
     "sybil>=9.3.0",
 ]
 optional-dependencies.dev = [


### PR DESCRIPTION
Bump beartype dependency to 0.22.9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Raise minimum beartype dependency to 0.22.9 in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b020344b4e88185d152fbdd85d73728dcb7aa80b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->