### PR TITLE
Add ty to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,8 @@ ci:
     - pyright
     - pyright-docs
     - pyright-verifytypes
+    - ty
+    - ty-docs
     - pyroma
     - ruff-check-fix
     - ruff-check-fix-docs
@@ -241,6 +243,24 @@ repos:
         language: python
         pass_filenames: false
         types_or: [python]
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty
+        name: ty
+        stages: [pre-push]
+        entry: uv run --extra=dev ty check
+        language: python
+        types_or: [python, toml]
+        pass_filenames: false
+        additional_dependencies: [uv==0.9.5]
+
+      - id: ty-docs
+        name: ty-docs
+        stages: [pre-push]
+        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
+          --command="uv run --extra=dev ty check"
+        language: python
+        types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
 
       - id: ruff-check-fix

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ optional-dependencies.dev = [
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "sybil==9.3.0",
+    "ty==0.0.1a34",
     "uv==0.9.17",
     "vulture==2.14",
     "yamlfix==1.19.0",


### PR DESCRIPTION
Add ty and ty-docs hooks to pre-commit configuration.

This adds type checking with ty, following the pattern established in other repositories.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `ty` type checking to pre-push (including docs) and includes `ty` in dev dependencies.
> 
> - **Pre-commit**:
>   - Add `ty` pre-push hook (`uv run --extra=dev ty check`).
>   - Add `ty-docs` pre-push hook to run `ty check` on code blocks via `doccmd`.
>   - Include `ty`/`ty-docs` in CI skip list.
> - **Dependencies**:
>   - Add `ty==0.0.1a34` to `optional-dependencies.dev` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2d3d4d23be343ca749a3606ad8cdc7893120b27c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->