### PR TITLE
Fix docstring for abstract parser

### DIFF
--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -1,5 +1,5 @@
 """
-A group parser for reST.
+An abstract parser for grouping blocks of source code.
 """
 
 from collections import defaultdict


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update the module docstring in `src/sybil_extras/parsers/abstract/grouped_source.py` to accurately describe it as an abstract parser for grouping source code blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b315125f9c6c4a074c4f15eeed24d2fa7b6dd603. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->