### PR TITLE
Remove a race condition

### DIFF
--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -116,8 +116,12 @@ class _Grouper:
         """Register a group's boundaries for later membership lookup.
 
         Called at parse time, not evaluation time.
+
+        Both locks are held together to ensure atomic registration. This
+        prevents a race condition where another thread could find the
+        boundary but fail to find the corresponding state.
         """
-        with self._group_boundaries_lock:
+        with self._group_boundaries_lock, self._group_state_lock:
             if document not in self._group_boundaries:
                 self._group_boundaries[document] = []
             self._group_boundaries[document].append(
@@ -127,8 +131,7 @@ class _Grouper:
                     end_position=end_position,
                 )
             )
-        key = _GroupStateKey(document=document, group_id=group_id)
-        with self._group_state_lock:
+            key = _GroupStateKey(document=document, group_id=group_id)
             self._group_state[key] = _GroupState(
                 start_position=start_position,
                 end_position=end_position,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Acquire both `_group_boundaries_lock` and `_group_state_lock` in `register_group` to atomically add boundaries and state, eliminating a race condition.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 04762949e51e14a9a1fd18dbc2bfa69f15a5f934. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->