### PR TITLE
Clearer error message

### DIFF
--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -366,7 +366,7 @@ class AbstractGroupedSourceParser:
 
             if marker_index + 1 >= len(markers):
                 msg = (
-                    f"'{self._directive}: start' was not followed by "
+                    f"'{self._directive}: start' must be followed by "
                     f"'{self._directive}: end'"
                 )
                 raise ValueError(msg)
@@ -375,7 +375,7 @@ class AbstractGroupedSourceParser:
             if end_action != "end":
                 msg = (
                     f"'{self._directive}: start' "
-                    f"was not followed by '{self._directive}: end'"
+                    f"must be followed by '{self._directive}: end'"
                 )
                 raise ValueError(msg)
 

--- a/tests/parsers/test_grouped_source.py
+++ b/tests/parsers/test_grouped_source.py
@@ -367,7 +367,7 @@ def test_start_after_start(language: MarkupLanguage, tmp_path: Path) -> None:
     sybil = Sybil(parsers=[group_parser])
     with pytest.raises(
         expected_exception=ValueError,
-        match="'group: start' was not followed by 'group: end'",
+        match="'group: start' must be followed by 'group: end'",
     ):
         sybil.parse(path=test_document)
 
@@ -392,7 +392,7 @@ def test_start_only(language: MarkupLanguage, tmp_path: Path) -> None:
     sybil = Sybil(parsers=[group_parser])
     with pytest.raises(
         expected_exception=ValueError,
-        match="'group: start' was not followed by 'group: end'",
+        match="'group: start' must be followed by 'group: end'",
     ):
         sybil.parse(path=test_document)
 
@@ -424,7 +424,7 @@ def test_start_start_end(language: MarkupLanguage, tmp_path: Path) -> None:
     # Error is raised at parse time since we validate structure upfront
     with pytest.raises(
         expected_exception=ValueError,
-        match="'group: start' was not followed by 'group: end'",
+        match="'group: start' must be followed by 'group: end'",
     ):
         sybil.parse(path=test_document)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Rephrases group directive validation errors to say "must be followed by" and updates tests to match.
> 
> - **Parser**:
>   - Update `AbstractGroupedSourceParser` validation messages to use "must be followed by" for `'directive: start'`/`'directive: end'` pairing.
> - **Tests**:
>   - Adjust `tests/parsers/test_grouped_source.py` regex matches to the new phrasing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 369bd414dc0584d177d02ee0ea030c6246978a5b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->