### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,9 @@ jobs:
 
       - name: Lint
         run: |
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-commit --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage pre-push --verbose
-          uv run --extra=dev pre-commit run --all-files --hook-stage manual --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-commit --verbose
+          uv run --extra=dev prek run --all-files --hook-stage pre-push --verbose
+          uv run --extra=dev prek run --all-files --hook-stage manual --verbose
         env:
           UV_PYTHON: ${{ matrix.python-version }}
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ fail_fast: true
 
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
-default_install_hook_types: [pre-commit, pre-push, commit-msg]
+default_install_hook_types: [pre-commit, pre-push]
 
 ci:
   # We use system Python, with required dependencies specified in pyproject.toml.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2025.4.3",
-    "pre-commit==4.5.1",
+    "prek==0.2.25",
     "pydocstyle==6.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",


### PR DESCRIPTION
Replace pre-commit with prek for running hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the hook runner and updates CI to use it.
> 
> - CI `Lint` step in `/.github/workflows/ci.yml` now runs `uv run ... prek run` for `pre-commit`, `pre-push`, and `manual` stages
> - Dev dependency switched from `pre-commit` to `prek` in `pyproject.toml`
> - `default_install_hook_types` in `.pre-commit-config.yaml` updated to `[pre-commit, pre-push]` (removes `commit-msg`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 653fb3107fa2df5cce45ddc2be8a00ac6c005d3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->