### PR TITLE
Make zizmor collection strict

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,7 +342,7 @@ repos:
 
       - id: zizmor
         name: zizmor
-        entry: uv run --extra=dev zizmor .github
+        entry: uv run --extra=dev zizmor --strict-collection .github
         language: python
         pass_filenames: false
         types_or: [yaml]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Tightens the pre-commit configuration for GitHub workflow scanning.
> 
> - Updates `zizmor` hook in `.pre-commit-config.yaml` to run with `--strict-collection` against `.github`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bca22e8144d422b7ece75a81d4131547f189dc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->