### PR TITLE
Use literal block scalar for changelog replace string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,8 +58,12 @@ jobs:
         uses: jacobtomlinson/gha-find-replace@v3
         with:
           find: "Next\n----"
-          replace: "Next\n----\n\n${{ steps.calver.outputs.release }}\n${{ steps.changelog_underline.outputs.underline\
-            \ }}\n"
+          replace: |
+            Next
+            ----
+
+            ${{ steps.calver.outputs.release }}
+            ${{ steps.changelog_underline.outputs.underline }}
           include: CHANGELOG.rst
           regex: false
 


### PR DESCRIPTION
Use literal block scalar (`|`) with actual newlines instead of escape sequences in the release workflow. This fixes zizmor warnings while being compatible with yamlfix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the release workflow to use a YAML literal block scalar for the changelog `replace` value, replacing escaped `\n` sequences with actual multi-line content.
> 
> - Changes `.github/workflows/release.yml` step using `jacobtomlinson/gha-find-replace@v3` to a `replace: |` block containing `Next`, underline, and the computed release/version underline
> - No other files or logic modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3c6f6fc03995c732fba0e82a6919064a9507872. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->