### PR TITLE
Ensure GroupedSourceParser cleans up state on evaluator failure

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Next
 ----
 
 * Fix MDX code block parsing when the info line is at EOF without a trailing newline.
+* Ensure ``GroupedSourceParser`` cleans up state when an evaluator raises an exception, allowing subsequent documents to be processed correctly.
 
 2025.12.13.4
 ------------


### PR DESCRIPTION
When an evaluator raises an exception during group evaluation, the grouper's internal state must be cleaned up properly. Otherwise, when the same parser instance is used to parse subsequent documents, stale state from the failed document could cause incorrect behavior.

This PR adds a test to verify that state cleanup works correctly across documents when an evaluator fails.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 201fcf4726377a3000770788fd3072144340044e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->