### PR TITLE
Fix docstring claiming default attribute_name value

### DIFF
--- a/src/sybil_extras/parsers/mdx/attribute_grouped_source.py
+++ b/src/sybil_extras/parsers/mdx/attribute_grouped_source.py
@@ -16,5 +16,5 @@ class AttributeGroupedSourceParser(AbstractAttributeGroupedSourceParser):
     """A parser for grouping MDX code blocks by attribute values.
 
     This parser groups code blocks that have the same value for a
-    specified attribute (default: 'group').
+    specified attribute.
     """


### PR DESCRIPTION
The `AttributeGroupedSourceParser` docstring incorrectly stated that `attribute_name` has a default value of `'group'`. Since the class inherits from `AbstractAttributeGroupedSourceParser` without overriding `__init__`, no such default exists.

Fixes #684

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `AttributeGroupedSourceParser` docstring to remove the incorrect claim that the grouped attribute defaults to `'group'`, clarifying that grouping is by a specified attribute.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f36df8bfca16918094bfb398e39356a417325291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->