### PR TITLE
Fix GroupAllParser deadlock with examples without source lexeme

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -19,6 +19,9 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
 
     Skip markers have parsed values like ('next', None) or ('start', None).
 
+    Only examples with a 'source' lexeme are counted, as these are the only
+    examples that will be collected by the GroupAllParser.
+
     Args:
         examples: The examples to count.
 
@@ -46,7 +49,7 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
                 in_skip_range = True
             else:
                 in_skip_range = False
-        else:
+        elif has_source(example=ex):
             non_skip_count += 1
             if skip_next or in_skip_range:
                 skipped_count += 1


### PR DESCRIPTION
## Summary

Fixes #683

The `count_expected_code_blocks` function counted all non-skip examples, but the `collect` method only processed examples with a `source` lexeme. This mismatch caused `finalize` to wait indefinitely for examples that would never arrive when custom parsers created examples without source lexemes.

## The Fix

Added a `has_source()` check in `count_expected_code_blocks` to only count examples that will actually be collected by the `GroupAllParser`.

## Testing

Added a test that creates a custom parser yielding examples without source lexemes, which deadlocks without the fix and passes with it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents deadlocks in group-all finalization by aligning expected block counting with what the collector actually processes.
> 
> - Update `count_expected_code_blocks` to increment only when `has_source(example)` is true, still honoring skip markers
> - Add `has_source()` utility in `_grouping_utils.py`
> - New test `test_examples_without_source_lexeme` verifies no deadlock when a custom parser yields examples without a `source` lexeme
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bfef7effe58be6814c30dbf628f24bd23aa14f40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->