### PR TITLE
Add support for Python 3.14

### DIFF
--- a/src/sybil_extras/parsers/mdx/codeblock.py
+++ b/src/sybil_extras/parsers/mdx/codeblock.py
@@ -22,15 +22,13 @@ _INFO_LINE_PATTERN = re.compile(
 )
 
 _ATTRIBUTE_PATTERN = re.compile(
-    pattern=\
-            r"""
+    pattern=r"""
     (?P<name>[A-Za-z0-9_.:-]+)
     \s*=\s*
     (?P<quote>["'])
     (?P<value>.*?)
     (?P=quote)
-    """
-       ,
+    """,
     flags=re.VERBOSE,
 )
 

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -30,8 +30,7 @@ def test_writes_modified_content(
     Writes modified content from namespace to source file.
     """
     markdown_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -40,8 +39,7 @@ def test_writes_modified_content(
         """
     )
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -50,8 +48,7 @@ def test_writes_modified_content(
         """
     )
     norg_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -61,8 +58,7 @@ def test_writes_modified_content(
     )
     original_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -98,8 +94,7 @@ def test_writes_modified_content(
     example.evaluate()
 
     markdown_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -108,8 +103,7 @@ def test_writes_modified_content(
         """
     )
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -118,8 +112,7 @@ def test_writes_modified_content(
         """
     )
     norg_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -129,8 +122,7 @@ def test_writes_modified_content(
     )
     expected_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -157,8 +149,7 @@ def test_writes_on_evaluator_exception(tmp_path: Path) -> None:
     subsequent checks fail.
     """
     original_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         original
         ```
@@ -219,53 +210,45 @@ def test_empty_code_block_write_content(
     Content can be written to an empty code block.
     """
     rst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         .. code-block:: python
 
         After empty code block
-        """
-           ,
+        """,
     )
     markdown_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
         ```
 
         After empty code block
-        """
-           ,
+        """,
     )
 
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
         ```
 
         After empty code block
-        """
-           ,
+        """,
     )
 
     norg_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
         @end
 
         After empty code block
-        """
-           ,
+        """,
     )
 
     content = {
@@ -299,8 +282,7 @@ def test_empty_code_block_write_content(
     (example,) = document.examples()
 
     markdown_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -312,8 +294,7 @@ def test_empty_code_block_write_content(
         """
     )
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -325,8 +306,7 @@ def test_empty_code_block_write_content(
         """
     )
     norg_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -341,8 +321,7 @@ def test_empty_code_block_write_content(
         # There is no code block in reStructuredText that ends with multiple
         # newlines.
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -377,21 +356,18 @@ def test_empty_code_block_with_options(
         return
 
     rst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         .. code-block:: python
            :emphasize-lines: 2,3
 
         After empty code block
-        """
-           ,
+        """,
     )
 
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -399,21 +375,18 @@ def test_empty_code_block_with_options(
         ```
 
         After empty code block
-        """
-           ,
+        """,
     )
 
     mdx_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python title="example.py"
         ```
 
         After empty code block
-        """
-           ,
+        """,
     )
 
     content = {
@@ -441,8 +414,7 @@ def test_empty_code_block_with_options(
     (example,) = document.examples()
 
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -455,8 +427,7 @@ def test_empty_code_block_with_options(
     )
     expected_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -469,8 +440,7 @@ def test_empty_code_block_with_options(
         ),
         MYST: myst_expected,
         MDX: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             ```python title="example.py"
@@ -504,8 +474,7 @@ def test_empty_code_block_write_empty(
     block.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         .. code-block:: python
@@ -546,8 +515,7 @@ def test_djot_quoted_code_block(tmp_path: Path) -> None:
     this test to cover Markdown / MDX / MyST.
     """
     original_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Some text before
 
         > ```python
@@ -585,8 +553,7 @@ def test_djot_quoted_code_block(tmp_path: Path) -> None:
     second_example.evaluate()
 
     expected_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Some text before
 
         > ```python
@@ -611,8 +578,7 @@ def test_no_write_when_content_unchanged(tmp_path: Path) -> None:
     Does not write when modified content matches original.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         original
         ```
@@ -648,8 +614,7 @@ def test_no_write_when_no_namespace_key(tmp_path: Path) -> None:
     Does not write when namespace key is not set.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         original
         ```
@@ -677,8 +642,7 @@ def test_custom_namespace_key(tmp_path: Path) -> None:
     Uses custom namespace key for modified content.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         original
         ```
@@ -709,8 +673,7 @@ def test_custom_namespace_key(tmp_path: Path) -> None:
     example.evaluate()
 
     expected_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         modified
         ```
@@ -724,8 +687,7 @@ def test_encoding_parameter(tmp_path: Path) -> None:
     Uses specified encoding when writing.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         original
         ```
@@ -754,8 +716,7 @@ def test_encoding_parameter(tmp_path: Path) -> None:
     example.evaluate()
 
     expected_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         modified
         ```
@@ -776,8 +737,7 @@ def test_indented_existing_block(
         return
 
     markdown_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
             ```python
@@ -787,8 +747,7 @@ def test_indented_existing_block(
         """
     )
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
             ```{code} python
@@ -798,8 +757,7 @@ def test_indented_existing_block(
         """
     )
     norg_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
             @code python
@@ -810,8 +768,7 @@ def test_indented_existing_block(
     )
     original_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
                 .. code-block:: python
@@ -849,8 +806,7 @@ def test_indented_existing_block(
     source_file_content = source_file.read_text(encoding="utf-8")
 
     markdown_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
             ```python
@@ -859,8 +815,7 @@ def test_indented_existing_block(
         """
     )
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
             ```{code} python
@@ -869,8 +824,7 @@ def test_indented_existing_block(
         """
     )
     norg_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
             @code python
@@ -880,8 +834,7 @@ def test_indented_existing_block(
     )
     expected_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
                 .. code-block:: python
@@ -911,8 +864,7 @@ def test_indented_empty_existing_block(
         return
 
     markdown_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
                 ```python
@@ -922,8 +874,7 @@ def test_indented_empty_existing_block(
         """
     )
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
                 ```{code} python
@@ -933,8 +884,7 @@ def test_indented_empty_existing_block(
         """
     )
     norg_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
                 @code python
@@ -945,8 +895,7 @@ def test_indented_empty_existing_block(
     )
     original_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
                     .. code-block:: python
@@ -983,8 +932,7 @@ def test_indented_empty_existing_block(
     source_file_content = source_file.read_text(encoding="utf-8")
 
     markdown_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
                 ```python
@@ -995,8 +943,7 @@ def test_indented_empty_existing_block(
         """
     )
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
                 ```{code} python
@@ -1007,8 +954,7 @@ def test_indented_empty_existing_block(
         """
     )
     norg_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
                 @code python
@@ -1020,8 +966,7 @@ def test_indented_empty_existing_block(
     )
     expected_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
                     .. code-block:: python
@@ -1046,8 +991,7 @@ def test_multiple_blocks(tmp_path: Path) -> None:
     Handles multiple code blocks correctly.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         first
         ```
@@ -1084,8 +1028,7 @@ def test_multiple_blocks(tmp_path: Path) -> None:
         example.evaluate()
 
     expected_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         modified_1
         ```
@@ -1138,8 +1081,7 @@ def test_changes_lines(tmp_path: Path) -> None:
     https://github.com/adamtheturtle/doccmd/issues/451.
     """
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         x = 1
         x = 1
@@ -1173,8 +1115,7 @@ def test_changes_lines(tmp_path: Path) -> None:
     first_example.evaluate()
     second_example.evaluate()
     expected_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         ```python
         pass
         ```

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -68,8 +68,7 @@ def fixture_rst_file(tmp_path: Path) -> Path:
     # * The code block is the last element in the file
     # * There is text outside the code block
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         .. code-block:: python
@@ -390,16 +389,14 @@ def test_pad(*, rst_file: Path, tmp_path: Path, use_pty_option: bool) -> None:
     example.evaluate()
     given_file_content = file_path.read_text(encoding="utf-8")
     expected_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
 
 
 
 
         x = 2 + 2
         assert x == 4
-        """\
-           ,
+        """,
     )
     assert given_file_content == expected_content
 
@@ -418,8 +415,7 @@ def test_write_to_file_new_content_trailing_newlines(
     block types that allow them.
     """
     markdown_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -429,8 +425,7 @@ def test_write_to_file_new_content_trailing_newlines(
         """
     )
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -440,8 +435,7 @@ def test_write_to_file_new_content_trailing_newlines(
         """
     )
     norg_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -452,8 +446,7 @@ def test_write_to_file_new_content_trailing_newlines(
     )
     original_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -494,8 +487,7 @@ def test_write_to_file_new_content_trailing_newlines(
     source_file_content = source_file.read_text(encoding="utf-8")
 
     markdown_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -505,8 +497,7 @@ def test_write_to_file_new_content_trailing_newlines(
         """
     )
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -516,8 +507,7 @@ def test_write_to_file_new_content_trailing_newlines(
         """
     )
     norg_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -530,8 +520,7 @@ def test_write_to_file_new_content_trailing_newlines(
         # There is no code block in reStructuredText that ends with multiple
         # newlines.
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -566,8 +555,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
     valid.
     """
     markdown_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -577,8 +565,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
         """
     )
     myst_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -588,8 +575,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
         """
     )
     norg_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -600,8 +586,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
     )
     original_content = {
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -640,8 +625,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
     source_file_content = source_file.read_text(encoding="utf-8")
 
     markdown_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```python
@@ -650,8 +634,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
         """
     )
     myst_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         ```{code} python
@@ -660,8 +643,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
         """
     )
     norg_expected = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         @code python
@@ -673,8 +655,7 @@ def test_write_to_file_new_content_no_trailing_newlines(
         # There is no code block in reStructuredText that ends with multiple
         # newlines.
         RESTRUCTUREDTEXT: textwrap.dedent(
-            text=\
-                 """\
+            text="""\
             Not in code block
 
             .. code-block:: python
@@ -727,8 +708,7 @@ def test_non_utf8_output(
     """
     Non-UTF-8 output is handled.
     """
-    sh_function =\
-                  b"""
+    sh_function = b"""
     echo "\xc0\x80"
     """
     script = tmp_path / "my_script.sh"
@@ -761,13 +741,11 @@ def test_no_file_left_behind_on_interruption(
     No file is left behind if the process is interrupted.
     """
     sleep_python_script_content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         import time
 
         time.sleep(0.5)
-        """
-           ,
+        """,
     )
 
     sleep_python_script = tmp_path / "sleep_comand.py"
@@ -997,8 +975,7 @@ def test_encoding(
 
     file_path = tmp_path / "file.txt"
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Not in code block
 
         .. code-block:: python
@@ -1142,8 +1119,7 @@ def test_markdown_code_block_line_number(
     # Line 4: syntax error here
     # Line 5: ```
     content = textwrap.dedent(
-        text=\
-             """\
+        text="""\
         Example
 
         ```python

--- a/tests/parsers/djot/test_codeblock.py
+++ b/tests/parsers/djot/test_codeblock.py
@@ -26,13 +26,11 @@ def test_fenced_code_block_outside_blockquote() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             ```python
             x = 1
             ```
-            """\
-               ,
+            """,
         )
     )
 
@@ -45,15 +43,13 @@ def test_code_block_in_blockquote_without_closing_fence() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             > ```python
             > x = 1
             > y = 2
 
             outside block quote
-            """\
-               ,
+            """,
         )
     )
 
@@ -68,15 +64,13 @@ def test_code_block_implicitly_closed_by_container_end() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             > ```python
             > code in a
             > block quote
 
             Paragraph.
-            """
-               ,
+            """,
         )
     )
 
@@ -89,13 +83,11 @@ def test_code_block_without_closing_fence_no_blockquote() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             ```python
             x = 1
             y = 2
-            """\
-               ,
+            """,
         )
     )
 
@@ -117,14 +109,12 @@ def test_code_block_in_nested_blockquote() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             > > ```python
             > > x = 1
 
             outside
-            """\
-               ,
+            """,
         )
     )
 
@@ -137,13 +127,11 @@ def test_code_block_with_wrong_language() -> None:
     """
     regions = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             ```javascript
             x = 1
             ```
-            """\
-               ,
+            """,
         )
     )
 
@@ -156,13 +144,11 @@ def test_code_block_empty_info_string() -> None:
     """
     regions = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             ```
             x = 1
             ```
-            """\
-               ,
+            """,
         )
     )
 
@@ -216,8 +202,7 @@ def test_multiple_code_blocks_with_invalid() -> None:
     Test multiple code blocks where some don't match the language filter.
     """
     text = dedent(
-        text=\
-             """\
+        text="""\
         ```javascript
         x = 1
         ```
@@ -225,8 +210,7 @@ def test_multiple_code_blocks_with_invalid() -> None:
         ```python
         y = 2
         ```
-        """\
-           ,
+        """,
     )
     regions = _parse(text=text)
 
@@ -245,8 +229,7 @@ def test_raw_lexer_skips_non_matching_and_continues() -> None:
         mapping=None,
     )
     text = dedent(
-        text=\
-             """\
+        text="""\
         ```javascript
         x = 1
         ```
@@ -254,8 +237,7 @@ def test_raw_lexer_skips_non_matching_and_continues() -> None:
         ```python
         y = 2
         ```
-        """\
-           ,
+        """,
     )
     document = Document(text=text, path="test.djot")
     regions = list(lexer(document=document))
@@ -274,14 +256,12 @@ def test_fence_with_non_matching_closer() -> None:
     # A fence in a blockquote, followed by a fence NOT in a blockquote
     # The second fence won't match because of different prefixes
     text = dedent(
-        text=\
-             """\
+        text="""\
         > ```python
         > code
         ```
         > ```
-        """
-           ,
+        """,
     )
     (region,) = _parse(text=text)
 
@@ -304,14 +284,12 @@ def test_region_end_respects_container_boundary_with_closing_fence() -> None:
     blockquote.
     """
     text = dedent(
-        text=\
-             """\
+        text="""\
         > ```python
         > x = 1
 
         > ```
-        """\
-           ,
+        """,
     )
     (region,) = _parse(text=text)
 

--- a/tests/parsers/djot/test_lexers.py
+++ b/tests/parsers/djot/test_lexers.py
@@ -16,13 +16,11 @@ def test_directive_with_argument() -> None:
     """
     lexer = DirectiveInDjotCommentLexer(directive="group", arguments=r".+")
     source_text = dedent(
-        text=\
-             """\
+        text="""\
         Before
         {% group: start %}
         After
-        """
-           ,
+        """,
     )
 
     expected_text = "{% group: start %}"

--- a/tests/parsers/norg/test_codeblock.py
+++ b/tests/parsers/norg/test_codeblock.py
@@ -24,13 +24,11 @@ def test_verbatim_ranged_tag_basic() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             x = 1
             @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -43,13 +41,11 @@ def test_verbatim_ranged_tag_without_language() -> None:
     """
     regions = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code
             x = 1
             @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -62,13 +58,11 @@ def test_verbatim_ranged_tag_wrong_language() -> None:
     """
     regions = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code javascript
             x = 1
             @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -81,15 +75,13 @@ def test_verbatim_ranged_tag_multiline() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             x = 1
             y = 2
             z = 3
             @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -102,12 +94,10 @@ def test_verbatim_ranged_tag_without_closing() -> None:
     """
     regions = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             x = 1
-            """\
-               ,
+            """,
         )
     )
 
@@ -120,13 +110,11 @@ def test_verbatim_ranged_tag_with_leading_whitespace() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
               @code python
               x = 1
               @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -139,8 +127,7 @@ def test_multiple_code_blocks() -> None:
     """
     regions = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             x = 1
             @end
@@ -150,8 +137,7 @@ def test_multiple_code_blocks() -> None:
             @code python
             y = 2
             @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -167,12 +153,10 @@ def test_empty_code_block() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             @end
-            """
-               ,
+            """,
         )
     )
 
@@ -185,15 +169,13 @@ def test_code_block_with_blank_lines() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             x = 1
 
             y = 2
             @end
-            """\
-               ,
+            """,
         )
     )
 
@@ -206,14 +188,12 @@ def test_nested_code_markers_in_content() -> None:
     """
     (region,) = _parse(
         text=dedent(
-            text=\
-                 """\
+            text="""\
             @code python
             # This is @code
             x = "@end"
             @end
-            """\
-               ,
+            """,
         )
     )
 

--- a/tests/parsers/norg/test_lexers.py
+++ b/tests/parsers/norg/test_lexers.py
@@ -17,13 +17,11 @@ def test_directive_with_argument() -> None:
     """
     lexer = DirectiveInNorgCommentLexer(directive="group", arguments=r".+")
     source_text = dedent(
-        text=\
-             """\
+        text="""\
         Before
         .group: start
         After
-        """
-           ,
+        """,
     )
 
     expected_text = ".group: start"
@@ -101,13 +99,11 @@ def test_verbatim_ranged_tag_lexer_no_mapping() -> None:
     """
     lexer = NorgVerbatimRangedTagLexer(language=r"python")
     source_text = dedent(
-        text=\
-             """\
+        text="""\
         @code python
         x = 1
         @end
-        """\
-           ,
+        """,
     )
 
     expected_text = "@code python\nx = 1\n@end"
@@ -132,13 +128,11 @@ def test_verbatim_ranged_tag_lexer_with_mapping() -> None:
         mapping={"language": "arguments", "source": "source"},
     )
     source_text = dedent(
-        text=\
-             """\
+        text="""\
         @code python
         x = 1
         @end
-        """\
-           ,
+        """,
     )
 
     expected_text = "@code python\nx = 1\n@end"
@@ -159,13 +153,11 @@ def test_verbatim_ranged_tag_lexer_no_language() -> None:
     # Use a pattern that matches any language including when not specified
     lexer = NorgVerbatimRangedTagLexer(language=r".+")
     source_text = dedent(
-        text=\
-             """\
+        text="""\
         @code
         x = 1
         @end
-        """\
-           ,
+        """,
     )
 
     expected_text = "@code\nx = 1\n@end"

--- a/tests/parsers/test_attribute_grouped_source.py
+++ b/tests/parsers/test_attribute_grouped_source.py
@@ -20,8 +20,7 @@ def test_attribute_group_single_group(tmp_path: Path) -> None:
     The attribute group parser groups examples with the same group attribute.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python group="example1"
         from pprint import pp
         ```
@@ -31,8 +30,7 @@ def test_attribute_group_single_group(tmp_path: Path) -> None:
         ```python group="example1"
         pp({"hello": "world"})
         ```
-        """
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -63,8 +61,7 @@ def test_attribute_group_multiple_groups(tmp_path: Path) -> None:
     Groups should not interleave to avoid region overlap issues.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python group="setup"
         x = []
         ```
@@ -84,8 +81,7 @@ def test_attribute_group_multiple_groups(tmp_path: Path) -> None:
         ```python group="example"
         y = [*y, 10]
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -116,8 +112,7 @@ def test_attribute_group_no_group_attribute(tmp_path: Path) -> None:
     Code blocks without the group attribute are not grouped.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python
         x = 1
         ```
@@ -129,8 +124,7 @@ def test_attribute_group_no_group_attribute(tmp_path: Path) -> None:
         ```python
         z = 3
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -159,8 +153,7 @@ def test_attribute_group_custom_attribute_name(tmp_path: Path) -> None:
     Custom attribute names can be used for grouping.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python mygroup="test1"
         a = 1
         ```
@@ -168,8 +161,7 @@ def test_attribute_group_custom_attribute_name(tmp_path: Path) -> None:
         ```python mygroup="test1"
         b = 2
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -199,8 +191,7 @@ def test_attribute_group_with_other_attributes(tmp_path: Path) -> None:
     Code blocks with multiple attributes still group correctly.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python title="example.py" group="setup" showLineNumbers
         value = 7
         ```
@@ -208,8 +199,7 @@ def test_attribute_group_with_other_attributes(tmp_path: Path) -> None:
         ```python group="setup" title="example2.py"
         result = value * 2
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -239,8 +229,7 @@ def test_attribute_group_pad_groups_false(tmp_path: Path) -> None:
     When pad_groups is False, groups are separated by single newlines.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python group="test"
         x = 1
         ```
@@ -252,8 +241,7 @@ def test_attribute_group_pad_groups_false(tmp_path: Path) -> None:
         ```python group="test"
         y = 2
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -283,8 +271,7 @@ def test_attribute_group_interleaved_groups(tmp_path: Path) -> None:
     Groups can interleave.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python group="setup"
         x = []
         ```
@@ -304,8 +291,7 @@ def test_attribute_group_interleaved_groups(tmp_path: Path) -> None:
         ```python group="example"
         y = [*y, 10]
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")
@@ -337,8 +323,7 @@ def test_attribute_group_ungrouped_evaluator(tmp_path: Path) -> None:
     Code blocks without the group attribute use the ungrouped_evaluator.
     """
     content = textwrap.dedent(
-        text=\
-             """
+        text="""
         ```python
         x = 1
         ```
@@ -354,8 +339,7 @@ def test_attribute_group_ungrouped_evaluator(tmp_path: Path) -> None:
         ```python
         w = 4
         ```
-        """\
-           ,
+        """,
     )
     test_document = tmp_path / "test.mdx"
     test_document.write_text(data=content, encoding="utf-8")


### PR DESCRIPTION
This PR adds support for Python 3.14:

- Added Python 3.14 classifier to pyproject.toml
- Updated `max_supported_python` to 3.14 in pyproject.toml
- Added Python 3.14 to the CI test matrix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds full Python 3.14 support across the project.
> 
> - **CI**: Include `3.14` in `python-version` matrix
> - **Tooling**: Update pre-commit `uvx --python` invocations from `3.13` to `3.14`
> - **Project metadata**: Add `"Programming Language :: Python :: 3.14"` classifier and set `[tool.pyproject-fmt].max_supported_python = "3.14"`
> - **Dev deps**: Replace `docformatter` with a 3.14-compatible fork
> - **Tests**: Add/expand parser and evaluator tests (Markdown/MDX/Djot/Norg) without functional runtime changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b0f95332b6ecd7e1fc0877a13ed7f8126adf468a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->