### PR TITLE
Replace docformatter with pydocstringformatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ ci:
     - check-manifest
     - deptry
     - doc8
-    - docformatter
+    - pydocstringformatter
     - interrogate
     - interrogate-docs
     - mypy
@@ -100,9 +100,9 @@ repos:
         additional_dependencies: [uv==0.9.5]
         stages: [pre-commit]
 
-      - id: docformatter
-        name: docformatter
-        entry: uv run --extra=dev -m docformatter --in-place
+      - id: pydocstringformatter
+        name: pydocstringformatter
+        entry: uv run --extra=dev pydocstringformatter
         language: python
         types_or: [python]
         additional_dependencies: [uv==0.9.5]

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,4 @@
-"""
-Setup for pytest.
-"""
+"""Setup for pytest."""
 
 from doctest import ELLIPSIS
 
@@ -16,9 +14,7 @@ from sybil.parsers.rest import (
 
 @beartype
 def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """
-    Apply the beartype decorator to all collected test functions.
-    """
+    """Apply the beartype decorator to all collected test functions."""
     for item in items:
         if isinstance(item, pytest.Function):
             item.obj = beartype(obj=item.obj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,11 +47,11 @@ optional-dependencies.dev = [
     "click==8.3.1",
     "deptry==0.24.0",
     "doc8==2.0.0",
-    "docformatter==1.7.7",
     "interrogate==1.7.0",
     "mypy[faster-cache]==1.19.1",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.0",
+    "pydocstringformatter==0.7.3",
     "pydocstyle==6.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
@@ -107,8 +107,8 @@ lint.ignore = [
     "C901",
     # Ruff warns that this conflicts with the formatter.
     "COM812",
-    # Allow our chosen docstring line-style - no one-line summary.
-    "D200",
+    # Allow our chosen docstring line-style - pydocstringformatter handles formatting
+    # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
     "D212",
     # Ruff warns that this conflicts with the formatter.
@@ -119,6 +119,9 @@ lint.ignore = [
 ]
 
 lint.per-file-ignores."doccmd_*.py" = [
+    # Allow our chosen docstring line-style - pydocstringformatter handles
+    # formatting but docstrings in docs may not match this style.
+    "D200",
     # Allow 'assert' in docs.
     "S101",
 ]
@@ -256,9 +259,6 @@ spelling-private-dict-file = 'spelling_private_dict.txt'
 # --spelling-private-dict-file option instead of raising a message.
 spelling-store-unknown-words = 'no'
 
-[tool.docformatter]
-make-summary-multi-line = true
-
 [tool.check-manifest]
 
 ignore = [
@@ -334,6 +334,12 @@ enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 exclude = [ "build", ".venv" ]
+
+[tool.pydocstringformatter]
+write = true
+split-summary-body = false
+max-line-length = 75
+linewrap-full-docstring = true
 
 [tool.interrogate]
 fail-under = 100

--- a/src/sybil_extras/__init__.py
+++ b/src/sybil_extras/__init__.py
@@ -1,3 +1,1 @@
-"""
-Add-ons for Sybil.
-"""
+"""Add-ons for Sybil."""

--- a/src/sybil_extras/evaluators/__init__.py
+++ b/src/sybil_extras/evaluators/__init__.py
@@ -1,3 +1,1 @@
-"""
-Evaluators for Sybil.
-"""
+"""Evaluators for Sybil."""

--- a/src/sybil_extras/evaluators/block_accumulator.py
+++ b/src/sybil_extras/evaluators/block_accumulator.py
@@ -1,6 +1,4 @@
-"""
-Block accumulator evaluator.
-"""
+"""Block accumulator evaluator."""
 
 from beartype import beartype
 from sybil.example import Example

--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -18,9 +18,7 @@ from sybil.typing import Evaluator
 
 @beartype
 def _get_within_code_block_indentation_prefix(example: Example) -> str:
-    """
-    Get the indentation of the parsed code in the example.
-    """
+    """Get the indentation of the parsed code in the example."""
     first_line = str(object=example.parsed).split(sep="\n", maxsplit=1)[0]
     region_text = example.document.text[
         example.region.start : example.region.end
@@ -73,7 +71,8 @@ def _get_modified_region_text(
     new_code_block_content: str,
 ) -> str:
     """
-    Get the region text to use after the example content is replaced.
+    Get the region text to use after the example content is
+    replaced.
     """
     first_line = original_region_text.split(sep="\n")[0]
     code_block_indent_prefix = first_line[
@@ -188,7 +187,8 @@ def _overwrite_example_content(
 
 @beartype
 class CodeBlockWriterEvaluator:
-    """An evaluator wrapper that writes modified content back to code blocks.
+    """An evaluator wrapper that writes modified content back to code
+    blocks.
 
     This evaluator wraps another evaluator and writes any modifications
     made to the example content back to the source document. It is useful

--- a/src/sybil_extras/evaluators/multi.py
+++ b/src/sybil_extras/evaluators/multi.py
@@ -1,6 +1,4 @@
-"""
-Use multiple evaluators.
-"""
+"""Use multiple evaluators."""
 
 from collections.abc import Sequence
 
@@ -11,20 +9,14 @@ from sybil.typing import Evaluator
 
 @beartype
 class MultiEvaluator:
-    """
-    Run multiple evaluators.
-    """
+    """Run multiple evaluators."""
 
     def __init__(self, evaluators: Sequence[Evaluator]) -> None:
-        """
-        Run multiple evaluators.
-        """
+        """Run multiple evaluators."""
         self._evaluators = evaluators
 
     def __call__(self, example: Example) -> str | None:
-        """
-        Run all evaluators.
-        """
+        """Run all evaluators."""
         for evaluator in self._evaluators:
             result = evaluator(example)
             if result is not None:

--- a/src/sybil_extras/evaluators/no_op.py
+++ b/src/sybil_extras/evaluators/no_op.py
@@ -1,6 +1,4 @@
-"""
-No-op Evaluator.
-"""
+"""No-op Evaluator."""
 
 from beartype import beartype
 from sybil.example import Example
@@ -14,6 +12,4 @@ class NoOpEvaluator:
     """
 
     def __call__(self, _: Example) -> None:
-        """
-        Do nothing.
-        """
+        """Do nothing."""

--- a/src/sybil_extras/evaluators/shell_evaluator.py
+++ b/src/sybil_extras/evaluators/shell_evaluator.py
@@ -1,6 +1,4 @@
-"""
-An evaluator for running shell commands on example files.
-"""
+"""An evaluator for running shell commands on example files."""
 
 import contextlib
 import os
@@ -27,9 +25,7 @@ if TYPE_CHECKING:
 @beartype
 @runtime_checkable
 class _ExampleModified(Protocol):
-    """
-    A protocol for a callback to run when an example is modified.
-    """
+    """A protocol for a callback to run when an example is modified."""
 
     def __call__(
         self,
@@ -37,9 +33,7 @@ class _ExampleModified(Protocol):
         example: Example,
         modified_example_content: str,
     ) -> None:
-        """
-        This function is called when an example is modified.
-        """
+        """This function is called when an example is modified."""
         # We disable a pylint warning here because the ellipsis is required
         # for Pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
@@ -52,9 +46,7 @@ def _run_command(
     env: Mapping[str, str] | None = None,
     use_pty: bool,
 ) -> subprocess.CompletedProcess[bytes]:
-    """
-    Run a command in a pseudo-terminal to preserve color.
-    """
+    """Run a command in a pseudo-terminal to preserve color."""
     chunk_size = 1024
 
     @beartype
@@ -62,9 +54,7 @@ def _run_command(
         stream_fileno: int,
         output: IO[bytes] | BytesIO,
     ) -> None:
-        """
-        Write from an input stream to an output stream.
-        """
+        """Write from an input stream to an output stream."""
         while chunk := os.read(stream_fileno, chunk_size):
             output.write(chunk)
             output.flush()
@@ -217,7 +207,8 @@ def _create_temp_file_path_for_example(
 @beartype
 class _ShellCommandRunner:
     """
-    Run a shell command on an example file (internal implementation).
+    Run a shell command on an example file (internal
+    implementation).
     """
 
     def __init__(
@@ -264,9 +255,7 @@ class _ShellCommandRunner:
         self._namespace_key = namespace_key
 
     def __call__(self, example: Example) -> None:
-        """
-        Run the shell command on the example file.
-        """
+        """Run the shell command on the example file."""
         if (
             self._use_pty and platform.system() == "Windows"
         ):  # pragma: no cover
@@ -345,9 +334,7 @@ class _ShellCommandRunner:
 
 @beartype
 class ShellCommandEvaluator:
-    """
-    Run a shell command on the example file.
-    """
+    """Run a shell command on the example file."""
 
     def __init__(
         self,
@@ -426,7 +413,5 @@ class ShellCommandEvaluator:
             self._evaluator = runner
 
     def __call__(self, example: Example) -> None:
-        """
-        Run the shell command on the example file.
-        """
+        """Run the shell command on the example file."""
         self._evaluator(example)

--- a/src/sybil_extras/languages.py
+++ b/src/sybil_extras/languages.py
@@ -1,6 +1,4 @@
-"""
-Tools for managing markup languages and generating snippets.
-"""
+"""Tools for managing markup languages and generating snippets."""
 
 import textwrap
 from collections.abc import Iterable
@@ -46,22 +44,16 @@ import sybil_extras.parsers.rest.sphinx_jinja2
 
 @runtime_checkable
 class _SphinxJinja2Parser(Protocol):
-    """
-    A parser for sphinx-jinja2 blocks.
-    """
+    """A parser for sphinx-jinja2 blocks."""
 
     def __init__(self, *, evaluator: Evaluator) -> None:
-        """
-        Construct a sphinx-jinja2 parser.
-        """
+        """Construct a sphinx-jinja2 parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Call the sphinx-jinja2 parser.
-        """
+        """Call the sphinx-jinja2 parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
@@ -69,38 +61,28 @@ class _SphinxJinja2Parser(Protocol):
 
 @runtime_checkable
 class _SkipParser(Protocol):
-    """
-    A parser for skipping custom directives.
-    """
+    """A parser for skipping custom directives."""
 
     def __init__(self, directive: str) -> None:
-        """
-        Construct a skip parser.
-        """
+        """Construct a skip parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Call the skip parser.
-        """
+        """Call the skip parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper managing skip state.
-        """
+        """Return the skipper managing skip state."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 
 @runtime_checkable
 class _GroupedSourceParser(Protocol):
-    """
-    A parser for grouping code blocks.
-    """
+    """A parser for grouping code blocks."""
 
     def __init__(
         self,
@@ -109,17 +91,13 @@ class _GroupedSourceParser(Protocol):
         evaluator: Evaluator,
         pad_groups: bool,
     ) -> None:
-        """
-        Construct a grouped code block parser.
-        """
+        """Construct a grouped code block parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Call the grouped code block parser.
-        """
+        """Call the grouped code block parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
@@ -127,9 +105,7 @@ class _GroupedSourceParser(Protocol):
 
 @runtime_checkable
 class _GroupAllParser(Protocol):
-    """
-    A parser for grouping all code blocks in a document.
-    """
+    """A parser for grouping all code blocks in a document."""
 
     def __init__(
         self,
@@ -137,62 +113,44 @@ class _GroupAllParser(Protocol):
         evaluator: Evaluator,
         pad_groups: bool,
     ) -> None:
-        """
-        Construct a parser that groups every code block.
-        """
+        """Construct a parser that groups every code block."""
         ...  # pylint: disable=unnecessary-ellipsis
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Call the group-all parser.
-        """
+        """Call the group-all parser."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 
 @runtime_checkable
 class CodeBlockBuilder(Protocol):
-    """
-    A callable that renders code blocks for a markup language.
-    """
+    """A callable that renders code blocks for a markup language."""
 
     def __call__(self, code: str, language: str) -> str:
-        """
-        Render ``code`` for ``language``.
-        """
+        """Render ``code`` for ``language``."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 
 @runtime_checkable
 class DirectiveBuilder(Protocol):
-    """
-    A callable that renders directives for a markup language.
-    """
+    """A callable that renders directives for a markup language."""
 
     def __call__(self, directive: str, argument: str | None = None) -> str:
-        """
-        Render ``directive`` with the optional ``argument``.
-        """
+        """Render ``directive`` with the optional ``argument``."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 
 @runtime_checkable
 class JinjaBlockBuilder(Protocol):
-    """
-    A callable that renders Jinja blocks for a markup language.
-    """
+    """A callable that renders Jinja blocks for a markup language."""
 
     def __call__(self, body: str) -> str:
-        """
-        Render a Jinja block containing ``body``.
-        """
+        """Render a Jinja block containing ``body``."""
         ...  # pylint: disable=unnecessary-ellipsis
 
 
 @beartype
 def _normalize_code(content: str) -> str:
-    """
-    Normalize code provided in tests into a block-friendly form.
-    """
+    """Normalize code provided in tests into a block-friendly form."""
     normalized = textwrap.dedent(text=content).strip("\n")
     if not normalized:
         return ""
@@ -201,18 +159,14 @@ def _normalize_code(content: str) -> str:
 
 @beartype
 def _markdown_code_block(code: str, language: str) -> str:
-    """
-    Build a Markdown/MyST code block.
-    """
+    """Build a Markdown/MyST code block."""
     normalized = _normalize_code(content=code)
     return f"```{language}\n{normalized}```"
 
 
 @beartype
 def _rst_code_block(code: str, language: str) -> str:
-    """
-    Build a reStructuredText code block.
-    """
+    """Build a reStructuredText code block."""
     normalized = _normalize_code(content=code)
     indented = (
         textwrap.indent(text=normalized, prefix="   ") if normalized else ""
@@ -225,9 +179,7 @@ def _html_comment_directive(
     directive: str,
     argument: str | None = None,
 ) -> str:
-    """
-    Render a directive embedded in an HTML comment.
-    """
+    """Render a directive embedded in an HTML comment."""
     suffix = f": {argument}" if argument is not None else ""
     return f"<!--- {directive}{suffix} -->"
 
@@ -237,9 +189,7 @@ def _percent_comment_directive(
     directive: str,
     argument: str | None = None,
 ) -> str:
-    """
-    Render a directive embedded in a percent-style comment.
-    """
+    """Render a directive embedded in a percent-style comment."""
     suffix = f": {argument}" if argument is not None else ""
     return f"% {directive}{suffix}"
 
@@ -249,9 +199,7 @@ def _rst_directive(
     directive: str,
     argument: str | None = None,
 ) -> str:
-    """
-    Render a directive for reStructuredText documents.
-    """
+    """Render a directive for reStructuredText documents."""
     if argument is None:
         return f".. {directive}:"
     return f".. {directive}: {argument}"
@@ -262,9 +210,7 @@ def _jsx_comment_directive(
     directive: str,
     argument: str | None = None,
 ) -> str:
-    """
-    Render a directive embedded in a JSX comment.
-    """
+    """Render a directive embedded in a JSX comment."""
     suffix = f": {argument}" if argument is not None else ""
     return f"{{/* {directive}{suffix} */}}"
 
@@ -274,18 +220,14 @@ def _djot_directive(
     directive: str,
     argument: str | None = None,
 ) -> str:
-    """
-    Render a directive embedded in a djot comment.
-    """
+    """Render a directive embedded in a djot comment."""
     suffix = f": {argument}" if argument is not None else ""
     return f"{{% {directive}{suffix} %}}"
 
 
 @beartype
 def _norg_code_block(code: str, language: str) -> str:
-    """
-    Build a Norg verbatim ranged tag code block.
-    """
+    """Build a Norg verbatim ranged tag code block."""
     normalized = _normalize_code(content=code)
     lang_param = f" {language}" if language else ""
     return f"@code{lang_param}\n{normalized}@end"
@@ -296,27 +238,21 @@ def _norg_directive(
     directive: str,
     argument: str | None = None,
 ) -> str:
-    """
-    Render a directive embedded in a norg infirm tag.
-    """
+    """Render a directive embedded in a norg infirm tag."""
     suffix = f": {argument}" if argument is not None else ""
     return f".{directive}{suffix}"
 
 
 @beartype
 def _myst_jinja_block(body: str) -> str:
-    """
-    Render a sphinx-jinja block for MyST.
-    """
+    """Render a sphinx-jinja block for MyST."""
     normalized = _normalize_code(content=body)
     return f"```{{jinja}}\n{normalized}```"
 
 
 @beartype
 def _rst_jinja_block(body: str) -> str:
-    """
-    Render a sphinx-jinja block for reStructuredText.
-    """
+    """Render a sphinx-jinja block for reStructuredText."""
     normalized = _normalize_code(content=body)
     indented = (
         textwrap.indent(text=normalized, prefix="   ") if normalized else ""
@@ -326,9 +262,7 @@ def _rst_jinja_block(body: str) -> str:
 
 @runtime_checkable
 class _CodeBlockParser(Protocol):
-    """
-    A parser for code blocks.
-    """
+    """A parser for code blocks."""
 
     def __init__(
         self,
@@ -336,17 +270,13 @@ class _CodeBlockParser(Protocol):
         language: str | None = None,
         evaluator: Evaluator | None = None,
     ) -> None:
-        """
-        Construct a code block parser.
-        """
+        """Construct a code block parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Call the code block parser.
-        """
+        """Call the code block parser."""
         # We disable a pylint warning here because the ellipsis is required
         # for pyright to recognize this as a protocol.
         ...  # pylint: disable=unnecessary-ellipsis
@@ -355,9 +285,7 @@ class _CodeBlockParser(Protocol):
 @beartype
 @dataclass(frozen=True)
 class MarkupLanguage:
-    """
-    A markup language.
-    """
+    """A markup language."""
 
     name: str
     markup_separator: str

--- a/src/sybil_extras/parsers/__init__.py
+++ b/src/sybil_extras/parsers/__init__.py
@@ -1,3 +1,1 @@
-"""
-Sybil parsers.
-"""
+"""Sybil parsers."""

--- a/src/sybil_extras/parsers/abstract/__init__.py
+++ b/src/sybil_extras/parsers/abstract/__init__.py
@@ -1,3 +1,1 @@
-"""
-Abstract parsers.
-"""
+"""Abstract parsers."""

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -1,6 +1,4 @@
-"""
-Shared utilities for grouping parsers.
-"""
+"""Shared utilities for grouping parsers."""
 
 from collections.abc import Iterable, Sequence
 
@@ -12,7 +10,8 @@ from sybil.typing import Evaluator
 
 @beartype
 def count_expected_code_blocks(examples: Iterable[Example]) -> int:
-    """Count the expected number of code blocks, accounting for skip markers.
+    """Count the expected number of code blocks, accounting for skip
+    markers.
 
     Skip directives (like 'skip: next' or 'skip: start/end') only affect
     examples that come AFTER them, so we must process in position order.

--- a/src/sybil_extras/parsers/abstract/attribute_grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/attribute_grouped_source.py
@@ -16,9 +16,7 @@ from ._grouping_utils import create_combined_region
 
 @beartype
 def _first_example_start_offset(examples: list[Example]) -> int:
-    """
-    Get the character offset where this group first appears.
-    """
+    """Get the character offset where this group first appears."""
     return examples[0].region.start
 
 
@@ -43,11 +41,14 @@ class AbstractAttributeGroupedSourceParser:
         Args:
             code_block_parser: A code block parser instance that parses
                 attributes.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             attribute_name: The attribute name to use for grouping.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
             ungrouped_evaluator: The evaluator to use for code blocks that
                 don't have the grouping attribute.

--- a/src/sybil_extras/parsers/abstract/group_all.py
+++ b/src/sybil_extras/parsers/abstract/group_all.py
@@ -25,14 +25,10 @@ from ._grouping_utils import (
 
 @beartype
 class _GroupAllState:
-    """
-    State for grouping all examples in a document.
-    """
+    """State for grouping all examples in a document."""
 
     def __init__(self, *, expected_code_blocks: int) -> None:
-        """
-        Initialize the group all state.
-        """
+        """Initialize the group all state."""
         self.expected_code_blocks = expected_code_blocks
         self.examples: list[Example] = []
         self.lock = threading.Lock()
@@ -42,9 +38,7 @@ class _GroupAllState:
 
 @beartype
 class _GroupAllEvaluator:
-    """
-    Evaluator that collects all examples and evaluates them as one.
-    """
+    """Evaluator that collects all examples and evaluates them as one."""
 
     def __init__(
         self,
@@ -54,10 +48,13 @@ class _GroupAllEvaluator:
     ) -> None:
         """
         Args:
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         self._document_state: dict[Document, _GroupAllState] = {}
@@ -78,9 +75,7 @@ class _GroupAllEvaluator:
         )
 
     def collect(self, example: Example) -> None:
-        """
-        Collect an example to be grouped.
-        """
+        """Collect an example to be grouped."""
         state = self._document_state[example.document]
 
         with state.ready:
@@ -93,9 +88,7 @@ class _GroupAllEvaluator:
         raise NotEvaluated
 
     def finalize(self, example: Example) -> None:
-        """
-        Finalize the grouping and evaluate all collected examples.
-        """
+        """Finalize the grouping and evaluate all collected examples."""
         state = self._document_state[example.document]
 
         with state.ready:
@@ -133,9 +126,7 @@ class _GroupAllEvaluator:
                 del self._document_state[example.document]
 
     def __call__(self, example: Example) -> None:
-        """
-        Call the evaluator.
-        """
+        """Call the evaluator."""
         # We use ``id`` equivalence rather than ``is`` to avoid a
         # ``pyright`` error:
         # https://github.com/microsoft/pyright/issues/9932
@@ -170,10 +161,13 @@ class AbstractGroupAllParser:
     ) -> None:
         """
         Args:
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         self._evaluator = _GroupAllEvaluator(

--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -29,9 +29,7 @@ from ._grouping_utils import (
 @beartype
 @dataclass(frozen=True)
 class _GroupStateKey:
-    """
-    Key for looking up group state.
-    """
+    """Key for looking up group state."""
 
     document: Document
     group_id: int
@@ -40,9 +38,7 @@ class _GroupStateKey:
 @beartype
 @dataclass
 class _GroupBoundary:
-    """
-    Boundary information for a group.
-    """
+    """Boundary information for a group."""
 
     group_id: int
     start_position: int
@@ -52,9 +48,7 @@ class _GroupBoundary:
 @beartype
 @dataclass
 class _GroupMarker:
-    """
-    A marker for a group start or end.
-    """
+    """A marker for a group start or end."""
 
     action: Literal["start", "end"]
     group_id: int
@@ -67,9 +61,7 @@ class _GroupMarker:
 
 @beartype
 class _GroupState:
-    """
-    State for a single group.
-    """
+    """State for a single group."""
 
     def __init__(
         self,
@@ -78,9 +70,7 @@ class _GroupState:
         end_position: int,
         expected_code_blocks: int,
     ) -> None:
-        """
-        Initialize the group state.
-        """
+        """Initialize the group state."""
         self.start_position = start_position
         self.end_position = end_position
         self.expected_code_blocks = expected_code_blocks
@@ -92,9 +82,7 @@ class _GroupState:
 
 @beartype
 class _Grouper:
-    """
-    Group blocks of source code.
-    """
+    """Group blocks of source code."""
 
     def __init__(
         self,
@@ -105,11 +93,14 @@ class _Grouper:
     ) -> None:
         """
         Args:
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             directive: The name of the directive to use for grouping.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         # State is keyed by _GroupStateKey to allow multiple groups
@@ -162,7 +153,8 @@ class _Grouper:
         document: Document,
         position: int,
     ) -> _GroupState | None:
-        """Find which group contains the given position and return its state.
+        """Find which group contains the given position and return its
+        state.
 
         This method atomically checks boundaries and retrieves state
         while holding both locks. This prevents a TOCTOU race where
@@ -185,9 +177,7 @@ class _Grouper:
         document: Document,
         group_id: int,
     ) -> _GroupState:
-        """
-        Get the state for a specific group.
-        """
+        """Get the state for a specific group."""
         key = _GroupStateKey(document=document, group_id=group_id)
         with self._group_state_lock:
             return self._group_state[key]
@@ -219,9 +209,7 @@ class _Grouper:
                 document.pop_evaluator(evaluator=self)
 
     def _evaluate_grouper_example(self, example: Example) -> None:
-        """
-        Evaluate a grouper marker.
-        """
+        """Evaluate a grouper marker."""
         marker: _GroupMarker = example.parsed
         state = self._get_group_state(
             document=example.document,
@@ -285,9 +273,7 @@ class _Grouper:
         raise NotEvaluated
 
     def __call__(self, /, example: Example) -> None:
-        """
-        Call the evaluator.
-        """
+        """Call the evaluator."""
         # We use ``id`` equivalence rather than ``is`` to avoid a
         # ``pyright`` error:
         # https://github.com/microsoft/pyright/issues/9932
@@ -324,11 +310,14 @@ class AbstractGroupedSourceParser:
         """
         Args:
             lexers: The lexers to use to find regions.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             directive: The name of the directive to use for grouping.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         self._lexers: LexerCollection = LexerCollection(lexers)
@@ -341,7 +330,8 @@ class AbstractGroupedSourceParser:
 
     def __call__(self, document: Document) -> Iterable[Region]:
         """
-        Yield regions to evaluate, grouped by start and end comments.
+        Yield regions to evaluate, grouped by start and end
+        comments.
         """
         # First pass: collect all start/end markers
         markers: list[tuple[int, int, str]] = []  # (start, end, action)

--- a/src/sybil_extras/parsers/djot/__init__.py
+++ b/src/sybil_extras/parsers/djot/__init__.py
@@ -1,3 +1,1 @@
-"""
-Parsers for djot.
-"""
+"""Parsers for djot."""

--- a/src/sybil_extras/parsers/djot/codeblock.py
+++ b/src/sybil_extras/parsers/djot/codeblock.py
@@ -1,6 +1,4 @@
-"""
-Code block parsing for Djot.
-"""
+"""Code block parsing for Djot."""
 
 import re
 from collections.abc import Iterable, Sequence
@@ -22,9 +20,7 @@ FENCE = re.compile(
 
 @beartype
 def _match_closes_existing(current: Match[str], existing: Match[str]) -> bool:
-    """
-    Determine whether the current fence closes the existing block.
-    """
+    """Determine whether the current fence closes the existing block."""
     current_fence = current.group("fence")
     existing_fence = existing.group("fence")
     same_type = current_fence[0] == existing_fence[0]
@@ -41,9 +37,7 @@ def _find_container_end(
     info_end: int,
     default_end: int,
 ) -> int:
-    """
-    Find where a block closes because its container ends.
-    """
+    """Find where a block closes because its container ends."""
     prefix = opening.group("prefix")
     if ">" not in prefix:
         return default_end
@@ -69,7 +63,8 @@ def _find_container_end(
 
 class DjotRawFencedCodeBlockLexer:
     """
-    A lexer for Djot fenced code blocks that respects block quote boundaries.
+    A lexer for Djot fenced code blocks that respects block quote
+    boundaries.
     """
 
     def __init__(
@@ -79,9 +74,7 @@ class DjotRawFencedCodeBlockLexer:
         ),
         mapping: dict[str, str] | None = None,
     ) -> None:
-        """
-        Initialize the lexer.
-        """
+        """Initialize the lexer."""
         self.info_pattern = info_pattern
         self.mapping = mapping
 
@@ -91,9 +84,7 @@ class DjotRawFencedCodeBlockLexer:
         document: Document,
         closing: Match[str] | None,
     ) -> Region | None:
-        """
-        Build a Region for a fenced block.
-        """
+        """Build a Region for a fenced block."""
         if closing is None:
             default_end = len(document.text)
         else:
@@ -142,9 +133,7 @@ class DjotRawFencedCodeBlockLexer:
         )
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for Djot fenced code blocks.
-        """
+        """Yield regions for Djot fenced code blocks."""
         index = 0
         while True:
             opening = FENCE.search(string=document.text, pos=index)
@@ -177,16 +166,12 @@ class DjotRawFencedCodeBlockLexer:
 
 
 class DjotFencedCodeBlockLexer(DjotRawFencedCodeBlockLexer):
-    """
-    A lexer for Djot fenced code blocks that captures languages.
-    """
+    """A lexer for Djot fenced code blocks that captures languages."""
 
     def __init__(
         self, language: str, mapping: dict[str, str] | None = None
     ) -> None:
-        """
-        Initialize the lexer.
-        """
+        """Initialize the lexer."""
         super().__init__(
             info_pattern=re.compile(
                 pattern=rf"(?P<language>{language})$\n", flags=re.MULTILINE
@@ -197,9 +182,7 @@ class DjotFencedCodeBlockLexer(DjotRawFencedCodeBlockLexer):
 
 @beartype
 class CodeBlockParser:
-    """
-    A parser for Djot fenced code blocks.
-    """
+    """A parser for Djot fenced code blocks."""
 
     def __init__(
         self,
@@ -229,7 +212,5 @@ class CodeBlockParser:
         )
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for Djot code blocks.
-        """
+        """Yield regions for Djot code blocks."""
         return self._parser(document)

--- a/src/sybil_extras/parsers/djot/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/djot/custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-A custom directive skip parser for Djot.
-"""
+"""A custom directive skip parser for Djot."""
 
 import re
 from collections.abc import Iterable
@@ -15,9 +13,7 @@ from sybil_extras.parsers.djot.lexers import DirectiveInDjotCommentLexer
 
 @beartype
 class CustomDirectiveSkipParser:
-    """
-    A custom directive skip parser for Djot.
-    """
+    """A custom directive skip parser for Djot."""
 
     def __init__(self, directive: str) -> None:
         """
@@ -34,13 +30,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield skip regions.
-        """
+        """Yield skip regions."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper used by the parser.
-        """
+        """Return the skipper used by the parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/djot/group_all.py
+++ b/src/sybil_extras/parsers/djot/group_all.py
@@ -1,6 +1,4 @@
-"""
-A parser that groups all code blocks in a Djot document.
-"""
+"""A parser that groups all code blocks in a Djot document."""
 
 from beartype import beartype
 
@@ -10,5 +8,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups all code blocks in a Djot document without markup.
+    A parser that groups all code blocks in a Djot document without
+    markup.
     """

--- a/src/sybil_extras/parsers/djot/grouped_source.py
+++ b/src/sybil_extras/parsers/djot/grouped_source.py
@@ -1,6 +1,4 @@
-"""
-A group parser for Djot.
-"""
+"""A group parser for Djot."""
 
 import re
 
@@ -15,9 +13,7 @@ from sybil_extras.parsers.djot.lexers import DirectiveInDjotCommentLexer
 
 @beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
-    """
-    A code block group parser for Djot.
-    """
+    """A code block group parser for Djot."""
 
     def __init__(
         self,
@@ -29,10 +25,13 @@ class GroupedSourceParser(AbstractGroupedSourceParser):
         """
         Args:
             directive: The name of the directive to use for grouping.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         lexers = [

--- a/src/sybil_extras/parsers/djot/lexers.py
+++ b/src/sybil_extras/parsers/djot/lexers.py
@@ -1,6 +1,4 @@
-"""
-Lexers for djot.
-"""
+"""Lexers for djot."""
 
 import re
 from collections.abc import Iterable
@@ -36,9 +34,7 @@ class DirectiveInDjotCommentLexer:
         arguments: str = r".*?",
         mapping: dict[str, str] | None = None,
     ) -> None:
-        """
-        Initialize the djot comment lexer.
-        """
+        """Initialize the djot comment lexer."""
         # Pattern to match djot comments with directives
         # Format: {% directive: argument %} or {% directive %}
         # The comment must be on its own line (with optional leading
@@ -58,9 +54,7 @@ class DirectiveInDjotCommentLexer:
         self.mapping = mapping
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for djot comment directives.
-        """
+        """Yield regions for djot comment directives."""
         for match in self.pattern.finditer(string=document.text):
             lexemes = match.groupdict()
             # Clean up the arguments - might be None if no colon was present

--- a/src/sybil_extras/parsers/markdown/__init__.py
+++ b/src/sybil_extras/parsers/markdown/__init__.py
@@ -1,3 +1,1 @@
-"""
-Custom parsers for Markdown.
-"""
+"""Custom parsers for Markdown."""

--- a/src/sybil_extras/parsers/markdown/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/markdown/custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-A custom directive skip parser for Markdown.
-"""
+"""A custom directive skip parser for Markdown."""
 
 import re
 from collections.abc import Iterable
@@ -14,9 +12,7 @@ from sybil.parsers.markdown.lexers import DirectiveInHTMLCommentLexer
 
 @beartype
 class CustomDirectiveSkipParser:
-    """
-    A custom directive skip parser for Markdown.
-    """
+    """A custom directive skip parser for Markdown."""
 
     def __init__(self, directive: str) -> None:
         """
@@ -33,13 +29,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield skip regions.
-        """
+        """Yield skip regions."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper used by the parser.
-        """
+        """Return the skipper used by the parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/markdown/group_all.py
+++ b/src/sybil_extras/parsers/markdown/group_all.py
@@ -1,6 +1,4 @@
-"""
-A parser that groups all code blocks in a Markdown document.
-"""
+"""A parser that groups all code blocks in a Markdown document."""
 
 from beartype import beartype
 
@@ -10,5 +8,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups all code blocks in a document without markup.
+    A parser that groups all code blocks in a document without
+    markup.
     """

--- a/src/sybil_extras/parsers/markdown/grouped_source.py
+++ b/src/sybil_extras/parsers/markdown/grouped_source.py
@@ -1,6 +1,4 @@
-"""
-A group parser for Markdown.
-"""
+"""A group parser for Markdown."""
 
 import re
 
@@ -15,9 +13,7 @@ from sybil_extras.parsers.abstract.grouped_source import (
 
 @beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
-    """
-    A code block group parser for Markdown.
-    """
+    """A code block group parser for Markdown."""
 
     def __init__(
         self,
@@ -29,10 +25,13 @@ class GroupedSourceParser(AbstractGroupedSourceParser):
         """
         Args:
             directive: The name of the directive to use for grouping.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         lexers = [

--- a/src/sybil_extras/parsers/markdown_it/__init__.py
+++ b/src/sybil_extras/parsers/markdown_it/__init__.py
@@ -1,3 +1,1 @@
-"""
-Markdown parsers using the MarkdownIt library.
-"""
+"""Markdown parsers using the MarkdownIt library."""

--- a/src/sybil_extras/parsers/markdown_it/_line_offsets.py
+++ b/src/sybil_extras/parsers/markdown_it/_line_offsets.py
@@ -1,6 +1,4 @@
-"""
-Line offset calculation for the markdown_it parsers.
-"""
+"""Line offset calculation for the markdown_it parsers."""
 
 from beartype import beartype
 

--- a/src/sybil_extras/parsers/markdown_it/codeblock.py
+++ b/src/sybil_extras/parsers/markdown_it/codeblock.py
@@ -21,7 +21,8 @@ _LANGUAGE_PATTERN = re.compile(pattern=r"^(?P<language>[^\s`]+)")
 
 @beartype
 class CodeBlockParser:
-    """A parser for Markdown fenced code blocks using the MarkdownIt library.
+    """A parser for Markdown fenced code blocks using the MarkdownIt
+    library.
 
     This parser uses a proper Markdown parsing library instead of regex
     to find and parse fenced code blocks.
@@ -37,9 +38,7 @@ class CodeBlockParser:
         language: str | None = None,
         evaluator: Evaluator | None = None,
     ) -> None:
-        """
-        Initialize the parser.
-        """
+        """Initialize the parser."""
         self._language = language
         self._evaluator = evaluator
 
@@ -52,9 +51,7 @@ class CodeBlockParser:
         raise NotImplementedError
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Parse the document and yield regions for each fenced code block.
-        """
+        """Parse the document and yield regions for each fenced code block."""
         md = MarkdownIt()
         # Disable the indented code block rule so that fenced code blocks
         # inside indented sections are still recognized as fences.

--- a/src/sybil_extras/parsers/markdown_it/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/markdown_it/custom_directive_skip.py
@@ -1,4 +1,5 @@
-"""A custom directive skip parser for Markdown using the MarkdownIt library.
+"""A custom directive skip parser for Markdown using the MarkdownIt
+library.
 
 This parser uses the MarkdownIt library instead of regex.
 """
@@ -35,13 +36,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield skip regions.
-        """
+        """Yield skip regions."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper used by the parser.
-        """
+        """Return the skipper used by the parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/markdown_it/group_all.py
+++ b/src/sybil_extras/parsers/markdown_it/group_all.py
@@ -11,5 +11,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups all code blocks in a document without markup.
+    A parser that groups all code blocks in a document without
+    markup.
     """

--- a/src/sybil_extras/parsers/markdown_it/grouped_source.py
+++ b/src/sybil_extras/parsers/markdown_it/grouped_source.py
@@ -32,10 +32,13 @@ class GroupedSourceParser(AbstractGroupedSourceParser):
         """
         Args:
             directive: The name of the directive to use for grouping.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         lexers = [

--- a/src/sybil_extras/parsers/markdown_it/lexers.py
+++ b/src/sybil_extras/parsers/markdown_it/lexers.py
@@ -39,9 +39,7 @@ class DirectiveInHTMLCommentLexer:
         directive: str,
         arguments: str = ".*?",
     ) -> None:
-        """
-        Initialize the lexer.
-        """
+        """Initialize the lexer."""
         # Build a pattern to match the directive inside the HTML comment
         # The pattern matches:
         # - Optional leading whitespace (for indented comments)
@@ -58,9 +56,7 @@ class DirectiveInHTMLCommentLexer:
         )
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Parse the document and yield regions for directive comments.
-        """
+        """Parse the document and yield regions for directive comments."""
         md = MarkdownIt()
         # Disable the indented code block rule. Without this, content
         # indented by 4+ spaces would be parsed as a code_block token

--- a/src/sybil_extras/parsers/mdx/__init__.py
+++ b/src/sybil_extras/parsers/mdx/__init__.py
@@ -1,3 +1,1 @@
-"""
-Custom parsers for MDX.
-"""
+"""Custom parsers for MDX."""

--- a/src/sybil_extras/parsers/mdx/codeblock.py
+++ b/src/sybil_extras/parsers/mdx/codeblock.py
@@ -1,6 +1,4 @@
-"""
-A code block parser for MDX with attribute support.
-"""
+"""A code block parser for MDX with attribute support."""
 
 import re
 from collections.abc import Iterable
@@ -35,9 +33,7 @@ _ATTRIBUTE_PATTERN = re.compile(
 
 @beartype
 class CodeBlockParser:
-    """
-    A parser for MDX fenced code blocks that preserves attributes.
-    """
+    """A parser for MDX fenced code blocks that preserves attributes."""
 
     def __init__(
         self,
@@ -76,9 +72,7 @@ class CodeBlockParser:
         )
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for code blocks, parsing any MDX attributes.
-        """
+        """Yield regions for code blocks, parsing any MDX attributes."""
         for region in self._parser(document):
             raw_attributes = region.lexemes.get("attributes_raw")
             parsed_attributes = self._parse_attributes(
@@ -91,9 +85,7 @@ class CodeBlockParser:
 
     @staticmethod
     def _parse_attributes(attr_string: str) -> dict[str, str]:
-        """
-        Parse key/value pairs from the info line attribute string.
-        """
+        """Parse key/value pairs from the info line attribute string."""
         if not attr_string:
             return {}
 

--- a/src/sybil_extras/parsers/mdx/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/mdx/custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-A custom directive skip parser for MDX.
-"""
+"""A custom directive skip parser for MDX."""
 
 import re
 from collections.abc import Iterable
@@ -17,13 +15,15 @@ from sybil_extras.parsers.mdx.lexers import DirectiveInJSXCommentLexer
 @beartype
 class CustomDirectiveSkipParser:
     """
-    A custom directive skip parser for MDX using HTML or JSX-style comments.
+    A custom directive skip parser for MDX using HTML or JSX-style
+    comments.
     """
 
     def __init__(self, directive: str) -> None:
         """
         Args:
-            directive: The directive name to match inside HTML or JSX comments.
+            directive: The directive name to match inside HTML or JSX
+        comments.
         """
         escaped_directive = re.escape(pattern=directive)
         lexers = [
@@ -35,13 +35,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield skip regions for the given document.
-        """
+        """Yield skip regions for the given document."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper handling skip state for this parser.
-        """
+        """Return the skipper handling skip state for this parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/mdx/group_all.py
+++ b/src/sybil_extras/parsers/mdx/group_all.py
@@ -1,6 +1,4 @@
-"""
-A parser that groups all code blocks in an MDX document.
-"""
+"""A parser that groups all code blocks in an MDX document."""
 
 from beartype import beartype
 
@@ -10,5 +8,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups every code block in a document without markup.
+    A parser that groups every code block in a document without
+    markup.
     """

--- a/src/sybil_extras/parsers/mdx/grouped_source.py
+++ b/src/sybil_extras/parsers/mdx/grouped_source.py
@@ -1,6 +1,4 @@
-"""
-A group parser for MDX.
-"""
+"""A group parser for MDX."""
 
 import re
 
@@ -16,9 +14,7 @@ from sybil_extras.parsers.mdx.lexers import DirectiveInJSXCommentLexer
 
 @beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
-    """
-    A code block group parser for MDX.
-    """
+    """A code block group parser for MDX."""
 
     def __init__(
         self,

--- a/src/sybil_extras/parsers/mdx/lexers.py
+++ b/src/sybil_extras/parsers/mdx/lexers.py
@@ -1,6 +1,4 @@
-"""
-Lexers for MDX parsing.
-"""
+"""Lexers for MDX parsing."""
 
 import re
 

--- a/src/sybil_extras/parsers/myst/__init__.py
+++ b/src/sybil_extras/parsers/myst/__init__.py
@@ -1,3 +1,1 @@
-"""
-Custom MyST parsers.
-"""
+"""Custom MyST parsers."""

--- a/src/sybil_extras/parsers/myst/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/myst/custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-A custom directive skip parser for MyST.
-"""
+"""A custom directive skip parser for MyST."""
 
 import re
 from collections.abc import Iterable
@@ -17,9 +15,7 @@ from sybil.parsers.myst.lexers import (
 
 @beartype
 class CustomDirectiveSkipParser:
-    """
-    A custom directive skip parser for MyST.
-    """
+    """A custom directive skip parser for MyST."""
 
     def __init__(self, directive: str) -> None:
         """
@@ -41,13 +37,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield skip regions.
-        """
+        """Yield skip regions."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper used by the parser.
-        """
+        """Return the skipper used by the parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/myst/group_all.py
+++ b/src/sybil_extras/parsers/myst/group_all.py
@@ -1,6 +1,4 @@
-"""
-A parser that groups all code blocks in a MyST document.
-"""
+"""A parser that groups all code blocks in a MyST document."""
 
 from beartype import beartype
 
@@ -10,5 +8,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups all code blocks in a document without markup.
+    A parser that groups all code blocks in a document without
+    markup.
     """

--- a/src/sybil_extras/parsers/myst/grouped_source.py
+++ b/src/sybil_extras/parsers/myst/grouped_source.py
@@ -1,6 +1,4 @@
-"""
-A group parser for MyST.
-"""
+"""A group parser for MyST."""
 
 import re
 
@@ -18,9 +16,7 @@ from sybil_extras.parsers.abstract.grouped_source import (
 
 @beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
-    """
-    A code block group parser for MyST.
-    """
+    """A code block group parser for MyST."""
 
     def __init__(
         self,
@@ -32,10 +28,13 @@ class GroupedSourceParser(AbstractGroupedSourceParser):
         """
         Args:
             directive: The name of the directive to use for grouping.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         lexers = [

--- a/src/sybil_extras/parsers/myst/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/myst/sphinx_jinja2.py
@@ -1,6 +1,4 @@
-"""
-A parser for sphinx-jinja2 blocks in MyST.
-"""
+"""A parser for sphinx-jinja2 blocks in MyST."""
 
 import re
 from collections.abc import Iterable
@@ -14,9 +12,7 @@ from sybil.typing import Evaluator
 
 @beartype
 class SphinxJinja2Parser:
-    """
-    A parser for sphinx-jinja2 blocks in MyST.
-    """
+    """A parser for sphinx-jinja2 blocks in MyST."""
 
     def __init__(
         self,
@@ -25,7 +21,8 @@ class SphinxJinja2Parser:
     ) -> None:
         """
         Args:
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
         """
         directive = "jinja"
         lexers = [
@@ -35,9 +32,7 @@ class SphinxJinja2Parser:
         self._evaluator = evaluator
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Parse the document for sphinx-jinja2 blocks.
-        """
+        """Parse the document for sphinx-jinja2 blocks."""
         for region in self._lexers(document):
             region.parsed = region.lexemes["source"]
             region.evaluator = self._evaluator

--- a/src/sybil_extras/parsers/norg/__init__.py
+++ b/src/sybil_extras/parsers/norg/__init__.py
@@ -1,3 +1,1 @@
-"""
-Parsers for Norg (Neorg) markup.
-"""
+"""Parsers for Norg (Neorg) markup."""

--- a/src/sybil_extras/parsers/norg/codeblock.py
+++ b/src/sybil_extras/parsers/norg/codeblock.py
@@ -1,6 +1,4 @@
-"""
-Code block parsing for Norg.
-"""
+"""Code block parsing for Norg."""
 
 import re
 from collections.abc import Iterable, Sequence
@@ -55,9 +53,7 @@ class NorgVerbatimRangedTagLexer:
         self._mapping = mapping
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for Norg verbatim ranged tags.
-        """
+        """Yield regions for Norg verbatim ranged tags."""
         index = 0
         while True:
             opening = self._opening_pattern.search(
@@ -118,9 +114,7 @@ class NorgVerbatimRangedTagLexer:
 
 @beartype
 class CodeBlockParser:
-    """
-    A parser for Norg verbatim ranged tags (code blocks).
-    """
+    """A parser for Norg verbatim ranged tags (code blocks)."""
 
     def __init__(
         self,
@@ -150,7 +144,5 @@ class CodeBlockParser:
         )
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for Norg code blocks.
-        """
+        """Yield regions for Norg code blocks."""
         return self._parser(document)

--- a/src/sybil_extras/parsers/norg/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/norg/custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-A custom directive skip parser for Norg.
-"""
+"""A custom directive skip parser for Norg."""
 
 import re
 from collections.abc import Iterable
@@ -15,9 +13,7 @@ from sybil_extras.parsers.norg.lexers import DirectiveInNorgCommentLexer
 
 @beartype
 class CustomDirectiveSkipParser:
-    """
-    A custom directive skip parser for Norg.
-    """
+    """A custom directive skip parser for Norg."""
 
     def __init__(self, directive: str) -> None:
         """
@@ -34,13 +30,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield skip regions.
-        """
+        """Yield skip regions."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper used by the parser.
-        """
+        """Return the skipper used by the parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/norg/group_all.py
+++ b/src/sybil_extras/parsers/norg/group_all.py
@@ -1,6 +1,4 @@
-"""
-A parser that groups all code blocks in a Norg document.
-"""
+"""A parser that groups all code blocks in a Norg document."""
 
 from beartype import beartype
 
@@ -10,5 +8,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups all code blocks in a document without markup.
+    A parser that groups all code blocks in a document without
+    markup.
     """

--- a/src/sybil_extras/parsers/norg/grouped_source.py
+++ b/src/sybil_extras/parsers/norg/grouped_source.py
@@ -1,6 +1,4 @@
-"""
-A group parser for Norg.
-"""
+"""A group parser for Norg."""
 
 import re
 
@@ -15,9 +13,7 @@ from sybil_extras.parsers.norg.lexers import DirectiveInNorgCommentLexer
 
 @beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
-    """
-    A code block group parser for Norg.
-    """
+    """A code block group parser for Norg."""
 
     def __init__(
         self,
@@ -29,10 +25,13 @@ class GroupedSourceParser(AbstractGroupedSourceParser):
         """
         Args:
             directive: The name of the directive to use for grouping.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         lexers = [

--- a/src/sybil_extras/parsers/norg/lexers.py
+++ b/src/sybil_extras/parsers/norg/lexers.py
@@ -1,6 +1,4 @@
-"""
-Lexers for norg.
-"""
+"""Lexers for norg."""
 
 import re
 from collections.abc import Iterable
@@ -36,9 +34,7 @@ class DirectiveInNorgCommentLexer:
         arguments: str = r".*?",
         mapping: dict[str, str] | None = None,
     ) -> None:
-        """
-        Initialize the norg infirm tag lexer.
-        """
+        """Initialize the norg infirm tag lexer."""
         # Pattern to match norg infirm tags with directives
         # Format: .directive: argument or .directive
         # The tag must be at the beginning of a line (with optional leading
@@ -53,9 +49,7 @@ class DirectiveInNorgCommentLexer:
         self.mapping = mapping
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions for norg infirm tag directives.
-        """
+        """Yield regions for norg infirm tag directives."""
         for match in self.pattern.finditer(string=document.text):
             lexemes = match.groupdict()
             # Clean up the arguments - might be None if no colon was present

--- a/src/sybil_extras/parsers/rest/__init__.py
+++ b/src/sybil_extras/parsers/rest/__init__.py
@@ -1,3 +1,1 @@
-"""
-Custom reST parsers.
-"""
+"""Custom reST parsers."""

--- a/src/sybil_extras/parsers/rest/custom_directive_skip.py
+++ b/src/sybil_extras/parsers/rest/custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-A custom directive skip parser for reST.
-"""
+"""A custom directive skip parser for reST."""
 
 import re
 from collections.abc import Iterable
@@ -14,9 +12,7 @@ from sybil.parsers.rest.lexers import DirectiveInCommentLexer
 
 @beartype
 class CustomDirectiveSkipParser:
-    """
-    A custom directive skip parser for reST.
-    """
+    """A custom directive skip parser for reST."""
 
     def __init__(self, directive: str) -> None:
         """
@@ -33,13 +29,9 @@ class CustomDirectiveSkipParser:
         self._abstract_skip_parser.directive = directive
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Yield regions to skip.
-        """
+        """Yield regions to skip."""
         return self._abstract_skip_parser(document=document)
 
     def get_skipper(self) -> Skipper:
-        """
-        Return the skipper used by the parser.
-        """
+        """Return the skipper used by the parser."""
         return self._abstract_skip_parser.skipper

--- a/src/sybil_extras/parsers/rest/group_all.py
+++ b/src/sybil_extras/parsers/rest/group_all.py
@@ -1,6 +1,4 @@
-"""
-A parser that groups all code blocks in a reStructuredText document.
-"""
+"""A parser that groups all code blocks in a reStructuredText document."""
 
 from beartype import beartype
 
@@ -10,5 +8,6 @@ from sybil_extras.parsers.abstract.group_all import AbstractGroupAllParser
 @beartype
 class GroupAllParser(AbstractGroupAllParser):
     """
-    A parser that groups all code blocks in a document without markup.
+    A parser that groups all code blocks in a document without
+    markup.
     """

--- a/src/sybil_extras/parsers/rest/grouped_source.py
+++ b/src/sybil_extras/parsers/rest/grouped_source.py
@@ -1,6 +1,4 @@
-"""
-A group parser for reST.
-"""
+"""A group parser for reST."""
 
 import re
 
@@ -15,9 +13,7 @@ from sybil_extras.parsers.abstract.grouped_source import (
 
 @beartype
 class GroupedSourceParser(AbstractGroupedSourceParser):
-    """
-    A code block group parser for reST.
-    """
+    """A code block group parser for reST."""
 
     def __init__(
         self,
@@ -29,10 +25,13 @@ class GroupedSourceParser(AbstractGroupedSourceParser):
         """
         Args:
             directive: The name of the directive to use for grouping.
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
             pad_groups: Whether to pad groups with empty lines.
-                This is useful for error messages that reference line numbers.
-                However, this is detrimental to commands that expect the file
+                This is useful for error messages that reference line
+        numbers.
+                However, this is detrimental to commands that expect the
+        file
                 to not have a bunch of newlines in it, such as formatters.
         """
         lexers = [

--- a/src/sybil_extras/parsers/rest/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/rest/sphinx_jinja2.py
@@ -1,6 +1,4 @@
-"""
-A parser for Sphinx jinja2 blocks in reST.
-"""
+"""A parser for Sphinx jinja2 blocks in reST."""
 
 import re
 from collections.abc import Iterable
@@ -14,9 +12,7 @@ from sybil.typing import Evaluator
 
 @beartype
 class SphinxJinja2Parser:
-    """
-    A parser for Sphinx jinja2 blocks in reST.
-    """
+    """A parser for Sphinx jinja2 blocks in reST."""
 
     def __init__(
         self,
@@ -25,7 +21,8 @@ class SphinxJinja2Parser:
     ) -> None:
         """
         Args:
-            evaluator: The evaluator to use for evaluating the combined region.
+            evaluator: The evaluator to use for evaluating the combined
+        region.
         """
         directive = "jinja"
         lexers = [
@@ -35,9 +32,7 @@ class SphinxJinja2Parser:
         self._evaluator = evaluator
 
     def __call__(self, document: Document) -> Iterable[Region]:
-        """
-        Parse the document for sphinx-jinja2 blocks.
-        """
+        """Parse the document for sphinx-jinja2 blocks."""
         for region in self._lexers(document):
             region.parsed = region.lexemes["source"]
             region.evaluator = self._evaluator

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for Sybil add-ons.
-"""
+"""Tests for Sybil add-ons."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,4 @@
-"""
-Shared pytest fixtures for tests package.
-"""
+"""Shared pytest fixtures for tests package."""
 
 import pytest
 
@@ -27,9 +25,7 @@ LANGUAGE_DIRECTIVE_BUILDER_IDS = [
 
 @pytest.fixture(name="language", params=ALL_LANGUAGES, ids=LANGUAGE_IDS)
 def fixture_language(request: pytest.FixtureRequest) -> MarkupLanguage:
-    """
-    Provide each supported markup language.
-    """
+    """Provide each supported markup language."""
     language = request.param
     if not isinstance(language, MarkupLanguage):  # pragma: no cover
         message = "Unexpected markup language fixture parameter"
@@ -43,9 +39,7 @@ def fixture_language(request: pytest.FixtureRequest) -> MarkupLanguage:
     ids=LANGUAGE_IDS,
 )
 def fixture_markup_language(request: pytest.FixtureRequest) -> MarkupLanguage:
-    """
-    Provide each supported markup language.
-    """
+    """Provide each supported markup language."""
     language: MarkupLanguage = request.param
     return language
 

--- a/tests/evaluators/__init__.py
+++ b/tests/evaluators/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for custom evaluators.
-"""
+"""Tests for custom evaluators."""

--- a/tests/evaluators/test_block_accumulator.py
+++ b/tests/evaluators/test_block_accumulator.py
@@ -1,6 +1,4 @@
-"""
-Tests for the BlockAccumulatorEvaluator.
-"""
+"""Tests for the BlockAccumulatorEvaluator."""
 
 from pathlib import Path
 
@@ -11,9 +9,7 @@ from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
 
 
 def test_accumulates_blocks(tmp_path: Path) -> None:
-    """
-    The evaluator accumulates parsed code blocks in the namespace.
-    """
+    """The evaluator accumulates parsed code blocks in the namespace."""
     content = """\
 .. code-block:: python
 
@@ -42,9 +38,7 @@ def test_accumulates_blocks(tmp_path: Path) -> None:
 
 
 def test_custom_namespace_key(tmp_path: Path) -> None:
-    """
-    The evaluator can use a custom namespace key.
-    """
+    """The evaluator can use a custom namespace key."""
     content = """\
 .. code-block:: python
 
@@ -70,9 +64,7 @@ def test_custom_namespace_key(tmp_path: Path) -> None:
 
 
 def test_single_block(tmp_path: Path) -> None:
-    """
-    The evaluator handles a single code block.
-    """
+    """The evaluator handles a single code block."""
     content = """\
 .. code-block:: python
 
@@ -93,9 +85,7 @@ def test_single_block(tmp_path: Path) -> None:
 
 
 def test_preserves_content(tmp_path: Path) -> None:
-    """
-    The evaluator preserves the exact content of code blocks.
-    """
+    """The evaluator preserves the exact content of code blocks."""
     content = """\
 .. code-block:: python
 

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -1,6 +1,4 @@
-"""
-Tests for the code_block_writer module.
-"""
+"""Tests for the code_block_writer module."""
 
 import textwrap
 from pathlib import Path
@@ -26,9 +24,7 @@ def test_writes_modified_content(
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
-    """
-    Writes modified content from namespace to source file.
-    """
+    """Writes modified content from namespace to source file."""
     markdown_content = textwrap.dedent(
         text="""\
         Not in code block
@@ -78,9 +74,7 @@ def test_writes_modified_content(
     source_file.write_text(data=original_content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = "modified"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -142,7 +136,8 @@ def test_writes_modified_content(
 
 
 def test_writes_on_evaluator_exception(tmp_path: Path) -> None:
-    """When the wrapped evaluator raises an exception, modifications are still
+    """When the wrapped evaluator raises an exception, modifications are
+    still
     written to the file before the exception is re-raised.
 
     This is important for formatters that should update files even when
@@ -159,20 +154,14 @@ def test_writes_on_evaluator_exception(tmp_path: Path) -> None:
     source_file.write_text(data=original_content, encoding="utf-8")
 
     class FailingEvaluator:
-        """
-        An evaluator that modifies content then raises an exception.
-        """
+        """An evaluator that modifies content then raises an exception."""
 
         def __init__(self, namespace_key: str) -> None:
-            """
-            Initialize the evaluator with a namespace key.
-            """
+            """Initialize the evaluator with a namespace key."""
             self._namespace_key = namespace_key
 
         def __call__(self, example: Example) -> None:
-            """
-            Modify content then raise an exception.
-            """
+            """Modify content then raise an exception."""
             example.document.namespace[self._namespace_key] = "modified"
             msg = "Intentional failure"
             raise RuntimeError(msg)
@@ -206,9 +195,7 @@ def test_empty_code_block_write_content(
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
-    """
-    Content can be written to an empty code block.
-    """
+    """Content can be written to an empty code block."""
     rst_content = textwrap.dedent(
         text="""\
         Not in code block
@@ -264,9 +251,7 @@ def test_empty_code_block_write_content(
     source_file.write_text(data=content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         # Add multiple newlines to show that they are not included in the file.
         # No code block in reStructuredText ends with multiple newlines.
         example.document.namespace["modified_content"] = "foobar\n\n"
@@ -348,7 +333,8 @@ def test_empty_code_block_with_options(
     markup_language: MarkupLanguage,
 ) -> None:
     """
-    It is possible to write content to an empty code block even if that code
+    It is possible to write content to an empty code block even if that
+    code
     block has options.
     """
     if markup_language in (MARKDOWN, MARKDOWN_IT, DJOT, NORG):
@@ -398,9 +384,7 @@ def test_empty_code_block_with_options(
     source_file.write_text(data=content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = "foobar"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -470,7 +454,8 @@ def test_empty_code_block_write_empty(
     new_content: str,
 ) -> None:
     """
-    No error is given when trying to write empty content to an empty code
+    No error is given when trying to write empty content to an empty
+    code
     block.
     """
     content = textwrap.dedent(
@@ -486,9 +471,7 @@ def test_empty_code_block_write_empty(
     source_file.write_text(data=content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = new_content
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -536,9 +519,7 @@ def test_djot_quoted_code_block(tmp_path: Path) -> None:
     djot_file.write_text(data=original_content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = "y = 5"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -574,9 +555,7 @@ def test_djot_quoted_code_block(tmp_path: Path) -> None:
 
 
 def test_no_write_when_content_unchanged(tmp_path: Path) -> None:
-    """
-    Does not write when modified content matches original.
-    """
+    """Does not write when modified content matches original."""
     content = textwrap.dedent(
         text="""\
         ```python
@@ -589,9 +568,7 @@ def test_no_write_when_content_unchanged(tmp_path: Path) -> None:
     original_mtime = source_file.stat().st_mtime
 
     def same_content_evaluator(example: Example) -> None:
-        """
-        Store same content in namespace.
-        """
+        """Store same content in namespace."""
         example.document.namespace["modified_content"] = "original\n"
 
     writer_evaluator = CodeBlockWriterEvaluator(
@@ -610,9 +587,7 @@ def test_no_write_when_content_unchanged(tmp_path: Path) -> None:
 
 
 def test_no_write_when_no_namespace_key(tmp_path: Path) -> None:
-    """
-    Does not write when namespace key is not set.
-    """
+    """Does not write when namespace key is not set."""
     content = textwrap.dedent(
         text="""\
         ```python
@@ -638,9 +613,7 @@ def test_no_write_when_no_namespace_key(tmp_path: Path) -> None:
 
 
 def test_custom_namespace_key(tmp_path: Path) -> None:
-    """
-    Uses custom namespace key for modified content.
-    """
+    """Uses custom namespace key for modified content."""
     content = textwrap.dedent(
         text="""\
         ```python
@@ -654,9 +627,7 @@ def test_custom_namespace_key(tmp_path: Path) -> None:
     custom_key = "custom_modified"
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content with custom key.
-        """
+        """Store modified content with custom key."""
         example.document.namespace[custom_key] = "modified"
 
     writer_evaluator = CodeBlockWriterEvaluator(
@@ -683,9 +654,7 @@ def test_custom_namespace_key(tmp_path: Path) -> None:
 
 
 def test_encoding_parameter(tmp_path: Path) -> None:
-    """
-    Uses specified encoding when writing.
-    """
+    """Uses specified encoding when writing."""
     content = textwrap.dedent(
         text="""\
         ```python
@@ -697,9 +666,7 @@ def test_encoding_parameter(tmp_path: Path) -> None:
     source_file.write_text(data=content, encoding="utf-16")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content.
-        """
+        """Store modified content."""
         example.document.namespace["modified_content"] = "modified"
 
     writer_evaluator = CodeBlockWriterEvaluator(
@@ -729,9 +696,7 @@ def test_indented_existing_block(
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
-    """
-    Changes are written to indented code blocks.
-    """
+    """Changes are written to indented code blocks."""
     if markup_language == NORG:
         # Norg does not support indented code blocks in the same way.
         return
@@ -788,9 +753,7 @@ def test_indented_existing_block(
     source_file.write_text(data=original_content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = "foobar"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -856,9 +819,7 @@ def test_indented_empty_existing_block(
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
-    """
-    Changes are written to indented empty code blocks.
-    """
+    """Changes are written to indented empty code blocks."""
     if markup_language == NORG:
         # Norg does not support indented code blocks in the same way.
         return
@@ -914,9 +875,7 @@ def test_indented_empty_existing_block(
     source_file.write_text(data=original_content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = "foobar"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -987,9 +946,7 @@ def test_indented_empty_existing_block(
 
 
 def test_multiple_blocks(tmp_path: Path) -> None:
-    """
-    Handles multiple code blocks correctly.
-    """
+    """Handles multiple code blocks correctly."""
     content = textwrap.dedent(
         text="""\
         ```python
@@ -1007,9 +964,7 @@ def test_multiple_blocks(tmp_path: Path) -> None:
     call_count = 0
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content with incrementing value.
-        """
+        """Store modified content with incrementing value."""
         nonlocal call_count
         call_count += 1
         example.document.namespace["modified_content"] = (
@@ -1043,7 +998,8 @@ def test_multiple_blocks(tmp_path: Path) -> None:
 
 def test_mixed_tab_space_indentation(tmp_path: Path) -> None:
     """
-    Changes are written correctly when code block indentation uses mixed tabs
+    Changes are written correctly when code block indentation uses mixed
+    tabs
     and spaces.
     """
     # Content with one tab followed by three spaces for indentation
@@ -1052,9 +1008,7 @@ def test_mixed_tab_space_indentation(tmp_path: Path) -> None:
     source_file.write_text(data=original_content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content in namespace.
-        """
+        """Store modified content in namespace."""
         example.document.namespace["modified_content"] = "y = 2"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
@@ -1074,7 +1028,8 @@ def test_mixed_tab_space_indentation(tmp_path: Path) -> None:
 
 
 def test_changes_lines(tmp_path: Path) -> None:
-    """If writing to a file changes the number of lines in the file, that does
+    """If writing to a file changes the number of lines in the file, that
+    does
     not affect the next code block.
 
     This test case is a narrow version of
@@ -1098,9 +1053,7 @@ def test_changes_lines(tmp_path: Path) -> None:
     source_file.write_text(data=content, encoding="utf-8")
 
     def modifying_evaluator(example: Example) -> None:
-        """
-        Store modified content.
-        """
+        """Store modified content."""
         example.document.namespace["modified_content"] = "pass"
 
     writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)

--- a/tests/evaluators/test_multi.py
+++ b/tests/evaluators/test_multi.py
@@ -1,6 +1,4 @@
-"""
-Tests for MultiEvaluator.
-"""
+"""Tests for MultiEvaluator."""
 
 from pathlib import Path
 
@@ -12,30 +10,22 @@ from sybil_extras.evaluators.multi import MultiEvaluator
 
 
 def _evaluator_1(example: Example) -> None:
-    """
-    Add `step_1` to namespace.
-    """
+    """Add `step_1` to namespace."""
     example.namespace["step_1"] = True
 
 
 def _evaluator_2(example: Example) -> None:
-    """
-    Add `step_2` to namespace.
-    """
+    """Add `step_2` to namespace."""
     example.namespace["step_2"] = True
 
 
 def _evaluator_3(example: Example) -> None:
-    """
-    Add `step_3` to namespace.
-    """
+    """Add `step_3` to namespace."""
     example.namespace["step_3"] = True
 
 
 def _failing_evaluator(example: Example) -> None:
-    """
-    Evaluator that intentionally fails by raising an AssertionError.
-    """
+    """Evaluator that intentionally fails by raising an AssertionError."""
     raise AssertionError(
         "Failure in failing_evaluator: " + str(object=example)
     )
@@ -43,9 +33,7 @@ def _failing_evaluator(example: Example) -> None:
 
 @pytest.fixture(name="rst_file")
 def fixture_rst_file(tmp_path: Path) -> Path:
-    """
-    Fixture to create a temporary RST file with Python code blocks.
-    """
+    """Fixture to create a temporary RST file with Python code blocks."""
     content = """
     .. code-block:: python
 
@@ -58,9 +46,7 @@ def fixture_rst_file(tmp_path: Path) -> Path:
 
 
 def test_multi_evaluator_runs_all(rst_file: Path) -> None:
-    """
-    MultiEvaluator runs all given evaluators.
-    """
+    """MultiEvaluator runs all given evaluators."""
     evaluators = [_evaluator_1, _evaluator_2, _evaluator_3]
     multi_evaluator = MultiEvaluator(evaluators=evaluators)
     parser = CodeBlockParser(language="python", evaluator=multi_evaluator)
@@ -76,9 +62,7 @@ def test_multi_evaluator_runs_all(rst_file: Path) -> None:
 
 
 def test_multi_evaluator_raises_on_failure(rst_file: Path) -> None:
-    """
-    MultiEvaluator raises an error if an evaluator fails.
-    """
+    """MultiEvaluator raises an error if an evaluator fails."""
     evaluators = [_evaluator_1, _failing_evaluator, _evaluator_3]
     multi_evaluator = MultiEvaluator(evaluators=evaluators)
     parser = CodeBlockParser(language="python", evaluator=multi_evaluator)
@@ -115,9 +99,7 @@ def test_multi_evaluator_propagates_failure_string(
     """
 
     def _string_returning_evaluator(example: Example) -> str:
-        """
-        Return a failure string instead of raising an exception.
-        """
+        """Return a failure string instead of raising an exception."""
         del example
         return failure_string
 

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -1,6 +1,4 @@
-"""
-Tests for the ShellCommandEvaluator.
-"""
+"""Tests for the ShellCommandEvaluator."""
 
 import os
 import platform
@@ -47,9 +45,7 @@ from sybil_extras.parsers.markdown_it.codeblock import (
 def fixture_use_pty_option(
     request: pytest.FixtureRequest,
 ) -> bool:
-    """
-    Test with and without the pseudo-terminal.
-    """
+    """Test with and without the pseudo-terminal."""
     use_pty = bool(request.param)
     if use_pty and platform.system() == "Windows":  # pragma: no cover
         pytest.skip(reason="PTY is not supported on Windows.")
@@ -58,9 +54,7 @@ def fixture_use_pty_option(
 
 @pytest.fixture(name="rst_file")
 def fixture_rst_file(tmp_path: Path) -> Path:
-    """
-    Fixture to create a temporary RST file with code blocks.
-    """
+    """Fixture to create a temporary RST file with code blocks."""
     # Relied upon features:
     #
     # * Includes exactly one code block
@@ -84,7 +78,8 @@ def fixture_rst_file(tmp_path: Path) -> Path:
 
 def test_error(*, rst_file: Path, use_pty_option: bool) -> None:
     """
-    A ``subprocess.CalledProcessError`` is raised if the command fails.
+    A ``subprocess.CalledProcessError`` is raised if the command
+    fails.
     """
     args = ["sh", "-c", "exit 1"]
     evaluator = ShellCommandEvaluator(
@@ -115,9 +110,7 @@ def test_output_shown(
     capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
-    """
-    Output is shown.
-    """
+    """Output is shown."""
     evaluator = ShellCommandEvaluator(
         args=[
             "sh",
@@ -151,9 +144,7 @@ def test_rm(
     capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
-    """
-    Output is shown.
-    """
+    """Output is shown."""
     evaluator = ShellCommandEvaluator(
         args=["rm"],
         pad_file=False,
@@ -177,9 +168,7 @@ def test_pass_env(
     tmp_path: Path,
     use_pty_option: bool,
 ) -> None:
-    """
-    It is possible to pass environment variables to the command.
-    """
+    """It is possible to pass environment variables to the command."""
     new_file = tmp_path / "new_file.txt"
     evaluator = ShellCommandEvaluator(
         args=[
@@ -208,9 +197,7 @@ def test_global_env(
     tmp_path: Path,
     use_pty_option: bool,
 ) -> None:
-    """
-    Global environment variables are sent to the command by default.
-    """
+    """Global environment variables are sent to the command by default."""
     env_key = "ENV_KEY"
     os.environ[env_key] = "ENV_VALUE"
     new_file = tmp_path / "new_file.txt"
@@ -274,7 +261,8 @@ def test_file_path(
 ) -> None:
     """
     The given file path is random and absolute, and starts with a name
-    resembling the documentation file name, but without any hyphens or periods,
+    resembling the documentation file name, but without any hyphens or
+    periods,
     except for the period for the final suffix.
     """
     evaluator = ShellCommandEvaluator(
@@ -309,9 +297,7 @@ def test_file_suffix(
     capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
-    """
-    The given file suffixes are used.
-    """
+    """The given file suffixes are used."""
     suffixes = [".example", ".foobar"]
     evaluator = ShellCommandEvaluator(
         args=["echo"],
@@ -340,9 +326,7 @@ def test_file_prefix(
     capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
-    """
-    The given file prefixes are used.
-    """
+    """The given file prefixes are used."""
     prefix = "custom_prefix"
     evaluator = ShellCommandEvaluator(
         args=["echo"],
@@ -409,7 +393,8 @@ def test_write_to_file_new_content_trailing_newlines(
     use_pty_option: bool,
     markup_language: MarkupLanguage,
 ) -> None:
-    """Changes are written to the original file iff `write_to_file` is True.
+    """Changes are written to the original file iff `write_to_file` is
+    True.
 
     If the content has trailing newlines, those are included in code
     block types that allow them.
@@ -549,7 +534,8 @@ def test_write_to_file_new_content_no_trailing_newlines(
     use_pty_option: bool,
     markup_language: MarkupLanguage,
 ) -> None:
-    """Changes are written to the original file iff `write_to_file` is True.
+    """Changes are written to the original file iff `write_to_file` is
+    True.
 
     If the content has no trailing newlines, the new code block is still
     valid.
@@ -678,7 +664,8 @@ def test_write_to_file_new_content_no_trailing_newlines(
 
 def test_pad_and_write(*, rst_file: Path, use_pty_option: bool) -> None:
     """
-    Changes are written to the original file without the added padding.
+    Changes are written to the original file without the added
+    padding.
     """
     original_content = rst_file.read_text(encoding="utf-8")
     rst_file.write_text(data=original_content, encoding="utf-8")
@@ -705,9 +692,7 @@ def test_non_utf8_output(
     tmp_path: Path,
     use_pty_option: bool,
 ) -> None:
-    """
-    Non-UTF-8 output is handled.
-    """
+    """Non-UTF-8 output is handled."""
     sh_function = b"""
     echo "\xc0\x80"
     """
@@ -737,9 +722,7 @@ def test_no_file_left_behind_on_interruption(
     rst_file: Path,
     tmp_path: Path,
 ) -> None:
-    """
-    No file is left behind if the process is interrupted.
-    """
+    """No file is left behind if the process is interrupted."""
     sleep_python_script_content = textwrap.dedent(
         text="""\
         import time
@@ -812,9 +795,7 @@ def test_newline_system(
     source_newline: str,
     use_pty_option: bool,
 ) -> None:
-    """
-    The system line endings are used by default.
-    """
+    """The system line endings are used by default."""
     rst_file_contents = rst_file.read_text(encoding="utf-8")
     rst_file.write_text(data=rst_file_contents, newline=source_newline)
     sh_function = """
@@ -857,9 +838,7 @@ def test_newline_given(
     expect_crlf: bool,
     use_pty_option: bool,
 ) -> None:
-    """
-    The given line ending option is used.
-    """
+    """The given line ending option is used."""
     rst_file_contents = rst_file.read_text(encoding="utf-8")
     rst_file.write_text(data=rst_file_contents, newline=source_newline)
     sh_function = """
@@ -889,7 +868,8 @@ def test_newline_given(
 
 def test_bad_command_error(*, rst_file: Path, use_pty_option: bool) -> None:
     """
-    A ``subprocess.CalledProcessError`` is raised if the command is invalid.
+    A ``subprocess.CalledProcessError`` is raised if the command is
+    invalid.
     """
     args = ["sh", "--unknownoption"]
     evaluator = ShellCommandEvaluator(
@@ -916,15 +896,11 @@ def test_bad_command_error(*, rst_file: Path, use_pty_option: bool) -> None:
 
 
 def test_click_runner(*, rst_file: Path, use_pty_option: bool) -> None:
-    """
-    The click runner can pick up the command output.
-    """
+    """The click runner can pick up the command output."""
 
     @click.command()
     def _main() -> None:
-        """
-        Click command to run a shell command.
-        """
+        """Click command to run a shell command."""
         evaluator = ShellCommandEvaluator(
             args=[
                 "sh",
@@ -966,9 +942,7 @@ def test_encoding(
     use_pty_option: bool,
     encoding: str,
 ) -> None:
-    """
-    The given encoding is used.
-    """
+    """The given encoding is used."""
     sh_function = """
     cp "$2" "$1"
     """
@@ -1013,13 +987,12 @@ def test_custom_on_modify_no_modification(
     use_pty_option: bool,
 ) -> None:
     """
-    The custom `on_modify` function is not called when there is a modification.
+    The custom `on_modify` function is not called when there is a
+    modification.
     """
 
     def on_modify(example: Example, modified_example_content: str) -> None:
-        """
-        Raise an error if this function is called.
-        """
+        """Raise an error if this function is called."""
         del example
         del modified_example_content
         msg = "This should not be called."
@@ -1057,13 +1030,12 @@ def test_custom_on_modify_with_modification(
     tmp_path: Path,
 ) -> None:
     """
-    The custom `on_modify` function is called when there is a modification.
+    The custom `on_modify` function is called when there is a
+    modification.
     """
 
     def on_modify(example: Example, modified_example_content: str) -> None:
-        """
-        Check that the given content is as expected.
-        """
+        """Check that the given content is as expected."""
         assert modified_example_content == "foobar"
         assert example.path == str(object=rst_file)
 

--- a/tests/parsers/__init__.py
+++ b/tests/parsers/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for custom parsers.
-"""
+"""Tests for custom parsers."""

--- a/tests/parsers/djot/__init__.py
+++ b/tests/parsers/djot/__init__.py
@@ -1,3 +1,1 @@
-"""
-Test package for djot parsers.
-"""
+"""Test package for djot parsers."""

--- a/tests/parsers/djot/conftest.py
+++ b/tests/parsers/djot/conftest.py
@@ -1,3 +1,1 @@
-"""
-Djot parser test configuration.
-"""
+"""Djot parser test configuration."""

--- a/tests/parsers/djot/test_codeblock.py
+++ b/tests/parsers/djot/test_codeblock.py
@@ -1,6 +1,4 @@
-"""
-Tests for Djot code block parsing.
-"""
+"""Tests for Djot code block parsing."""
 
 import re
 from textwrap import dedent
@@ -12,18 +10,14 @@ from sybil_extras.parsers.djot.codeblock import DjotRawFencedCodeBlockLexer
 
 
 def _parse(text: str) -> list[Region]:
-    """
-    Parse the supplied Djot text for Python code blocks.
-    """
+    """Parse the supplied Djot text for Python code blocks."""
     parser = DJOT.code_block_parser_cls(language="python")
     document = Document(text=text, path="doc.djot")
     return list(parser(document=document))
 
 
 def test_fenced_code_block_outside_blockquote() -> None:
-    """
-    A standard fenced code block is parsed.
-    """
+    """A standard fenced code block is parsed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -38,9 +32,7 @@ def test_fenced_code_block_outside_blockquote() -> None:
 
 
 def test_code_block_in_blockquote_without_closing_fence() -> None:
-    """
-    A Djot code block can be closed by the end of its blockquote.
-    """
+    """A Djot code block can be closed by the end of its blockquote."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -57,7 +49,8 @@ def test_code_block_in_blockquote_without_closing_fence() -> None:
 
 
 def test_code_block_implicitly_closed_by_container_end() -> None:
-    """A code block without a closing fence is closed when its container ends.
+    """A code block without a closing fence is closed when its container
+    ends.
 
     This follows the djot spec: "A code block ... ends with ... the end of the
     document or enclosing block, if no such line is encountered."
@@ -79,7 +72,8 @@ def test_code_block_implicitly_closed_by_container_end() -> None:
 
 def test_code_block_without_closing_fence_no_blockquote() -> None:
     """
-    A code block without a closing fence outside a blockquote extends to EOF.
+    A code block without a closing fence outside a blockquote extends to
+    EOF.
     """
     (region,) = _parse(
         text=dedent(
@@ -95,18 +89,14 @@ def test_code_block_without_closing_fence_no_blockquote() -> None:
 
 
 def test_code_block_with_no_newline_at_end() -> None:
-    """
-    A code block that ends without a trailing newline.
-    """
+    """A code block that ends without a trailing newline."""
     (region,) = _parse(text="```python\nx = 1")
 
     assert region.parsed == "x = 1"
 
 
 def test_code_block_in_nested_blockquote() -> None:
-    """
-    A code block in a nested blockquote is properly closed.
-    """
+    """A code block in a nested blockquote is properly closed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -122,9 +112,7 @@ def test_code_block_in_nested_blockquote() -> None:
 
 
 def test_code_block_with_wrong_language() -> None:
-    """
-    A code block with a different language is not parsed.
-    """
+    """A code block with a different language is not parsed."""
     regions = _parse(
         text=dedent(
             text="""\
@@ -139,9 +127,7 @@ def test_code_block_with_wrong_language() -> None:
 
 
 def test_code_block_empty_info_string() -> None:
-    """
-    A code block with no language specified is not parsed.
-    """
+    """A code block with no language specified is not parsed."""
     regions = _parse(
         text=dedent(
             text="""\
@@ -156,36 +142,28 @@ def test_code_block_empty_info_string() -> None:
 
 
 def test_code_block_in_blockquote_at_eof() -> None:
-    """
-    A code block in a blockquote that reaches EOF without container end.
-    """
+    """A code block in a blockquote that reaches EOF without container end."""
     (region,) = _parse(text="> ```python\n> x = 1\n> y = 2")
 
     assert region.parsed == "x = 1\ny = 2"
 
 
 def test_code_block_empty_after_opening() -> None:
-    """
-    A code block in a blockquote with opening right at the end.
-    """
+    """A code block in a blockquote with opening right at the end."""
     (region,) = _parse(text="> ```python\n")
 
     assert region.parsed == ""
 
 
 def test_code_block_in_blockquote_no_newline_after_prefix_change() -> None:
-    """
-    A code block in blockquote where the prefix changes without newline.
-    """
+    """A code block in blockquote where the prefix changes without newline."""
     (region,) = _parse(text="> ```python\n> code\nno prefix")
 
     assert region.parsed == "code\n"
 
 
 def test_raw_lexer_without_mapping() -> None:
-    """
-    Test DjotRawFencedCodeBlockLexer without a mapping parameter.
-    """
+    """Test DjotRawFencedCodeBlockLexer without a mapping parameter."""
     lexer = DjotRawFencedCodeBlockLexer(
         info_pattern=re.compile(pattern=r"python$\n", flags=re.MULTILINE),
         mapping=None,
@@ -199,7 +177,8 @@ def test_raw_lexer_without_mapping() -> None:
 
 def test_multiple_code_blocks_with_invalid() -> None:
     """
-    Test multiple code blocks where some don't match the language filter.
+    Test multiple code blocks where some don't match the language
+    filter.
     """
     text = dedent(
         text="""\
@@ -248,7 +227,8 @@ def test_raw_lexer_skips_non_matching_and_continues() -> None:
 
 
 def test_fence_with_non_matching_closer() -> None:
-    """Test a code block where a fence is found but doesn't match as a closer.
+    """Test a code block where a fence is found but doesn't match as a
+    closer.
 
     This hits the branch 156->149 where match_closes_existing returns
     False and we continue looking for other fences.
@@ -271,7 +251,8 @@ def test_fence_with_non_matching_closer() -> None:
 
 
 def test_region_end_respects_container_boundary_with_closing_fence() -> None:
-    """Test that region end respects container boundary even when closing fence
+    """Test that region end respects container boundary even when closing
+    fence
     exists in a separate container.
 
     Per the Djot spec, "a code block closes...or the end of the document or

--- a/tests/parsers/djot/test_lexers.py
+++ b/tests/parsers/djot/test_lexers.py
@@ -1,6 +1,4 @@
-"""
-Tests for custom djot lexers.
-"""
+"""Tests for custom djot lexers."""
 
 from textwrap import dedent
 
@@ -11,9 +9,7 @@ from sybil_extras.parsers.djot.lexers import DirectiveInDjotCommentLexer
 
 
 def test_directive_with_argument() -> None:
-    """
-    A directive with an argument is captured along with its text.
-    """
+    """A directive with an argument is captured along with its text."""
     lexer = DirectiveInDjotCommentLexer(directive="group", arguments=r".+")
     source_text = dedent(
         text="""\
@@ -36,7 +32,8 @@ def test_directive_with_argument() -> None:
 
 def test_directive_without_argument() -> None:
     """
-    A directive without an argument yields an empty arguments lexeme.
+    A directive without an argument yields an empty arguments
+    lexeme.
     """
     lexer = DirectiveInDjotCommentLexer(directive="skip")
     source_text = "{% skip %}\n"
@@ -53,9 +50,7 @@ def test_directive_without_argument() -> None:
 
 
 def test_directive_with_mapping() -> None:
-    """
-    Lexeme names can be remapped when requested.
-    """
+    """Lexeme names can be remapped when requested."""
     lexer = DirectiveInDjotCommentLexer(
         directive="custom",
         arguments=r".*",
@@ -75,7 +70,8 @@ def test_directive_with_mapping() -> None:
 
 
 def test_directive_stops_at_first_closing_delimiter() -> None:
-    """Djot comments end at the first ``%}``, so text after it is not captured.
+    """Djot comments end at the first ``%}``, so text after it is not
+    captured.
 
     This tests that ``{% group: foo %} bar %}`` captures only ``foo`` as
     the argument, not ``foo %} bar``.
@@ -110,7 +106,8 @@ def test_arguments_pattern_filters_matches() -> None:
 
 def test_argument_with_percent_sign() -> None:
     """
-    Arguments can contain percent signs that are not followed by ``}``.
+    Arguments can contain percent signs that are not followed by
+    ``}``.
     """
     lexer = DirectiveInDjotCommentLexer(directive="group", arguments=r".+")
     source_text = "{% group: 50% off %}\n"

--- a/tests/parsers/markdown_it/__init__.py
+++ b/tests/parsers/markdown_it/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for the markdown_it parser module.
-"""
+"""Tests for the markdown_it parser module."""

--- a/tests/parsers/markdown_it/test_codeblock.py
+++ b/tests/parsers/markdown_it/test_codeblock.py
@@ -1,6 +1,4 @@
-"""
-Tests for the markdown_it CodeBlockParser.
-"""
+"""Tests for the markdown_it CodeBlockParser."""
 
 from pathlib import Path
 
@@ -56,7 +54,8 @@ def test_unclosed_fence_no_trailing_newline(tmp_path: Path) -> None:
 
 
 def test_code_block_with_empty_info_string(tmp_path: Path) -> None:
-    """Code blocks with no language specified are matched when language=None.
+    """Code blocks with no language specified are matched when
+    language=None.
 
     When a code block has an empty info string (just ```), the pattern
     won't match and block_language should be set to empty string.

--- a/tests/parsers/markdown_it/test_lexers.py
+++ b/tests/parsers/markdown_it/test_lexers.py
@@ -1,6 +1,4 @@
-"""
-Tests for the markdown_it lexers.
-"""
+"""Tests for the markdown_it lexers."""
 
 from pathlib import Path
 
@@ -14,9 +12,7 @@ from sybil_extras.parsers.markdown_it.custom_directive_skip import (
 
 
 def test_directive_at_eof_without_trailing_newline(tmp_path: Path) -> None:
-    """
-    Directive at end of file without trailing newline is recognized.
-    """
+    """Directive at end of file without trailing newline is recognized."""
     # No trailing newline after the directive
     content = "<!--- custom-skip: next -->"
     test_file = tmp_path / "test.md"

--- a/tests/parsers/myst/__init__.py
+++ b/tests/parsers/myst/__init__.py
@@ -1,3 +1,1 @@
-"""
-Test for custom MyST parsers.
-"""
+"""Test for custom MyST parsers."""

--- a/tests/parsers/myst/test_sphinx_jinja2.py
+++ b/tests/parsers/myst/test_sphinx_jinja2.py
@@ -1,6 +1,4 @@
-"""
-Tests for the sphinx-jinja2 parser for MyST.
-"""
+"""Tests for the sphinx-jinja2 parser for MyST."""
 
 from pathlib import Path
 
@@ -12,7 +10,8 @@ from sybil_extras.parsers.myst.sphinx_jinja2 import SphinxJinja2Parser
 
 def test_sphinx_jinja2(*, tmp_path: Path) -> None:
     """
-    The ``SphinxJinja2Parser`` extracts information from sphinx-jinja2 blocks.
+    The ``SphinxJinja2Parser`` extracts information from sphinx-jinja2
+    blocks.
     """
     # These examples are taken from the sphinx-jinja2 documentation.
     content = """\

--- a/tests/parsers/norg/__init__.py
+++ b/tests/parsers/norg/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for Norg parsers.
-"""
+"""Tests for Norg parsers."""

--- a/tests/parsers/norg/test_codeblock.py
+++ b/tests/parsers/norg/test_codeblock.py
@@ -1,6 +1,4 @@
-"""
-Tests for Norg code block parsing.
-"""
+"""Tests for Norg code block parsing."""
 
 from textwrap import dedent
 
@@ -10,18 +8,14 @@ from sybil_extras.languages import NORG
 
 
 def _parse(text: str) -> list[Region]:
-    """
-    Parse the supplied Norg text for Python code blocks.
-    """
+    """Parse the supplied Norg text for Python code blocks."""
     parser = NORG.code_block_parser_cls(language="python")
     document = Document(text=text, path="doc.norg")
     return list(parser(document=document))
 
 
 def test_verbatim_ranged_tag_basic() -> None:
-    """
-    A standard verbatim ranged tag code block is parsed.
-    """
+    """A standard verbatim ranged tag code block is parsed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -36,9 +30,7 @@ def test_verbatim_ranged_tag_basic() -> None:
 
 
 def test_verbatim_ranged_tag_without_language() -> None:
-    """
-    A code block without language specification is not parsed.
-    """
+    """A code block without language specification is not parsed."""
     regions = _parse(
         text=dedent(
             text="""\
@@ -53,9 +45,7 @@ def test_verbatim_ranged_tag_without_language() -> None:
 
 
 def test_verbatim_ranged_tag_wrong_language() -> None:
-    """
-    A code block with a different language is not parsed.
-    """
+    """A code block with a different language is not parsed."""
     regions = _parse(
         text=dedent(
             text="""\
@@ -70,9 +60,7 @@ def test_verbatim_ranged_tag_wrong_language() -> None:
 
 
 def test_verbatim_ranged_tag_multiline() -> None:
-    """
-    A multi-line code block is properly parsed.
-    """
+    """A multi-line code block is properly parsed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -89,9 +77,7 @@ def test_verbatim_ranged_tag_multiline() -> None:
 
 
 def test_verbatim_ranged_tag_without_closing() -> None:
-    """
-    A code block without a closing tag is not parsed.
-    """
+    """A code block without a closing tag is not parsed."""
     regions = _parse(
         text=dedent(
             text="""\
@@ -105,9 +91,7 @@ def test_verbatim_ranged_tag_without_closing() -> None:
 
 
 def test_verbatim_ranged_tag_with_leading_whitespace() -> None:
-    """
-    A code block with leading whitespace is properly parsed.
-    """
+    """A code block with leading whitespace is properly parsed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -122,9 +106,7 @@ def test_verbatim_ranged_tag_with_leading_whitespace() -> None:
 
 
 def test_multiple_code_blocks() -> None:
-    """
-    Multiple code blocks in the same document are all parsed.
-    """
+    """Multiple code blocks in the same document are all parsed."""
     regions = _parse(
         text=dedent(
             text="""\
@@ -148,9 +130,7 @@ def test_multiple_code_blocks() -> None:
 
 
 def test_empty_code_block() -> None:
-    """
-    An empty code block is parsed.
-    """
+    """An empty code block is parsed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -164,9 +144,7 @@ def test_empty_code_block() -> None:
 
 
 def test_code_block_with_blank_lines() -> None:
-    """
-    A code block with blank lines is properly parsed.
-    """
+    """A code block with blank lines is properly parsed."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -183,9 +161,7 @@ def test_code_block_with_blank_lines() -> None:
 
 
 def test_nested_code_markers_in_content() -> None:
-    """
-    Code blocks can contain text that looks like markers.
-    """
+    """Code blocks can contain text that looks like markers."""
     (region,) = _parse(
         text=dedent(
             text="""\
@@ -201,9 +177,7 @@ def test_nested_code_markers_in_content() -> None:
 
 
 def test_trailing_whitespace_after_end() -> None:
-    """
-    A code block with trailing whitespace after @end is parsed.
-    """
+    """A code block with trailing whitespace after @end is parsed."""
     # Use a raw string to preserve the trailing spaces after @end
     text = "@code python\nx = 1\n@end   \n"
     (region,) = _parse(text=text)

--- a/tests/parsers/norg/test_lexers.py
+++ b/tests/parsers/norg/test_lexers.py
@@ -1,6 +1,4 @@
-"""
-Tests for custom norg lexers.
-"""
+"""Tests for custom norg lexers."""
 
 from textwrap import dedent
 
@@ -12,9 +10,7 @@ from sybil_extras.parsers.norg.lexers import DirectiveInNorgCommentLexer
 
 
 def test_directive_with_argument() -> None:
-    """
-    A directive with an argument is captured along with its text.
-    """
+    """A directive with an argument is captured along with its text."""
     lexer = DirectiveInNorgCommentLexer(directive="group", arguments=r".+")
     source_text = dedent(
         text="""\
@@ -37,7 +33,8 @@ def test_directive_with_argument() -> None:
 
 def test_directive_without_argument() -> None:
     """
-    A directive without an argument yields an empty arguments lexeme.
+    A directive without an argument yields an empty arguments
+    lexeme.
     """
     lexer = DirectiveInNorgCommentLexer(directive="skip")
     source_text = ".skip\n"
@@ -54,9 +51,7 @@ def test_directive_without_argument() -> None:
 
 
 def test_directive_with_mapping() -> None:
-    """
-    Lexeme names can be remapped when requested.
-    """
+    """Lexeme names can be remapped when requested."""
     lexer = DirectiveInNorgCommentLexer(
         directive="custom",
         arguments=r".*",
@@ -76,9 +71,7 @@ def test_directive_with_mapping() -> None:
 
 
 def test_directive_with_leading_whitespace() -> None:
-    """
-    A directive with leading whitespace is matched.
-    """
+    """A directive with leading whitespace is matched."""
     lexer = DirectiveInNorgCommentLexer(directive="skip")
     source_text = "  .skip\n"
 
@@ -94,9 +87,7 @@ def test_directive_with_leading_whitespace() -> None:
 
 
 def test_verbatim_ranged_tag_lexer_no_mapping() -> None:
-    """
-    The verbatim ranged tag lexer works without a mapping.
-    """
+    """The verbatim ranged tag lexer works without a mapping."""
     lexer = NorgVerbatimRangedTagLexer(language=r"python")
     source_text = dedent(
         text="""\
@@ -120,9 +111,7 @@ def test_verbatim_ranged_tag_lexer_no_mapping() -> None:
 
 
 def test_verbatim_ranged_tag_lexer_with_mapping() -> None:
-    """
-    The verbatim ranged tag lexer works with a mapping.
-    """
+    """The verbatim ranged tag lexer works with a mapping."""
     lexer = NorgVerbatimRangedTagLexer(
         language=r"python",
         mapping={"language": "arguments", "source": "source"},
@@ -148,7 +137,8 @@ def test_verbatim_ranged_tag_lexer_with_mapping() -> None:
 
 def test_verbatim_ranged_tag_lexer_no_language() -> None:
     """
-    The verbatim ranged tag lexer handles code blocks without a language.
+    The verbatim ranged tag lexer handles code blocks without a
+    language.
     """
     # Use a pattern that matches any language including when not specified
     lexer = NorgVerbatimRangedTagLexer(language=r".+")
@@ -174,7 +164,8 @@ def test_verbatim_ranged_tag_lexer_no_language() -> None:
 
 def test_verbatim_ranged_tag_lexer_no_newline_after_opening() -> None:
     """
-    The lexer handles the case where @end immediately follows opening tag.
+    The lexer handles the case where @end immediately follows opening
+    tag.
     """
     lexer = NorgVerbatimRangedTagLexer(language=r".+")
     # @code python immediately followed by @end (no newline after opening)

--- a/tests/parsers/rest/__init__.py
+++ b/tests/parsers/rest/__init__.py
@@ -1,3 +1,1 @@
-"""
-Tests for custom reST parsers.
-"""
+"""Tests for custom reST parsers."""

--- a/tests/parsers/rest/test_sphinx_jinja2.py
+++ b/tests/parsers/rest/test_sphinx_jinja2.py
@@ -1,6 +1,4 @@
-"""
-Tests for the sphinx-jinja2 parser for reST.
-"""
+"""Tests for the sphinx-jinja2 parser for reST."""
 
 from pathlib import Path
 
@@ -12,7 +10,8 @@ from sybil_extras.parsers.rest.sphinx_jinja2 import SphinxJinja2Parser
 
 def test_sphinx_jinja2(*, tmp_path: Path) -> None:
     """
-    The ``SphinxJinja2Parser`` extracts information from sphinx-jinja2 blocks.
+    The ``SphinxJinja2Parser`` extracts information from sphinx-jinja2
+    blocks.
     """
     # These examples are taken from the sphinx-jinja2 documentation.
     content = """\

--- a/tests/parsers/test_attribute_grouped_source.py
+++ b/tests/parsers/test_attribute_grouped_source.py
@@ -1,6 +1,4 @@
-"""
-Attribute-based grouped source parser tests for MDX.
-"""
+"""Attribute-based grouped source parser tests for MDX."""
 
 import textwrap
 from pathlib import Path
@@ -17,7 +15,8 @@ from sybil_extras.parsers.mdx.codeblock import CodeBlockParser
 
 def test_attribute_group_single_group(tmp_path: Path) -> None:
     """
-    The attribute group parser groups examples with the same group attribute.
+    The attribute group parser groups examples with the same group
+    attribute.
     """
     content = textwrap.dedent(
         text="""
@@ -108,9 +107,7 @@ def test_attribute_group_multiple_groups(tmp_path: Path) -> None:
 
 
 def test_attribute_group_no_group_attribute(tmp_path: Path) -> None:
-    """
-    Code blocks without the group attribute are not grouped.
-    """
+    """Code blocks without the group attribute are not grouped."""
     content = textwrap.dedent(
         text="""
         ```python
@@ -149,9 +146,7 @@ def test_attribute_group_no_group_attribute(tmp_path: Path) -> None:
 
 
 def test_attribute_group_custom_attribute_name(tmp_path: Path) -> None:
-    """
-    Custom attribute names can be used for grouping.
-    """
+    """Custom attribute names can be used for grouping."""
     content = textwrap.dedent(
         text="""
         ```python mygroup="test1"
@@ -187,9 +182,7 @@ def test_attribute_group_custom_attribute_name(tmp_path: Path) -> None:
 
 
 def test_attribute_group_with_other_attributes(tmp_path: Path) -> None:
-    """
-    Code blocks with multiple attributes still group correctly.
-    """
+    """Code blocks with multiple attributes still group correctly."""
     content = textwrap.dedent(
         text="""
         ```python title="example.py" group="setup" showLineNumbers
@@ -226,7 +219,8 @@ def test_attribute_group_with_other_attributes(tmp_path: Path) -> None:
 
 def test_attribute_group_pad_groups_false(tmp_path: Path) -> None:
     """
-    When pad_groups is False, groups are separated by single newlines.
+    When pad_groups is False, groups are separated by single
+    newlines.
     """
     content = textwrap.dedent(
         text="""
@@ -267,9 +261,7 @@ def test_attribute_group_pad_groups_false(tmp_path: Path) -> None:
 
 
 def test_attribute_group_interleaved_groups(tmp_path: Path) -> None:
-    """
-    Groups can interleave.
-    """
+    """Groups can interleave."""
     content = textwrap.dedent(
         text="""
         ```python group="setup"
@@ -319,9 +311,7 @@ def test_attribute_group_interleaved_groups(tmp_path: Path) -> None:
 
 
 def test_attribute_group_ungrouped_evaluator(tmp_path: Path) -> None:
-    """
-    Code blocks without the group attribute use the ungrouped_evaluator.
-    """
+    """Code blocks without the group attribute use the ungrouped_evaluator."""
     content = textwrap.dedent(
         text="""
         ```python

--- a/tests/parsers/test_custom_directive_skip.py
+++ b/tests/parsers/test_custom_directive_skip.py
@@ -1,6 +1,4 @@
-"""
-Custom directive skip parser tests shared across markup languages.
-"""
+"""Custom directive skip parser tests shared across markup languages."""
 
 from pathlib import Path
 
@@ -16,9 +14,7 @@ def test_skip(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    The custom directive skip parser can be used to set skips.
-    """
+    """The custom directive skip parser can be used to set skips."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -87,9 +83,7 @@ def test_directive_name_in_evaluate_error(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    The directive name is included in evaluation errors.
-    """
+    """The directive name is included in evaluation errors."""
     language, directive_builder = language_directive_builder
     content = directive_builder(
         directive="custom-skip",
@@ -117,9 +111,7 @@ def test_directive_name_in_parse_error(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    The directive name is included in parsing errors.
-    """
+    """The directive name is included in parsing errors."""
     language, directive_builder = language_directive_builder
     content = directive_builder(
         directive="custom-skip",
@@ -146,7 +138,8 @@ def test_directive_name_not_regex_escaped(
     tmp_path: Path,
 ) -> None:
     """
-    Directive names containing regex characters are matched literally.
+    Directive names containing regex characters are matched
+    literally.
     """
     language, directive_builder = language_directive_builder
     directive = "custom-skip[has_square_brackets]"

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -1,6 +1,4 @@
-"""
-Group-all parser tests shared across markup languages.
-"""
+"""Group-all parser tests shared across markup languages."""
 
 import subprocess
 from collections.abc import Iterable
@@ -21,9 +19,7 @@ from sybil_extras.languages import (
 
 
 def test_group_all(language: MarkupLanguage, tmp_path: Path) -> None:
-    """
-    All code blocks are grouped into a single block.
-    """
+    """All code blocks are grouped into a single block."""
     content = language.markup_separator.join(
         [
             language.code_block_builder(code="x = []", language="python"),
@@ -66,9 +62,7 @@ def test_group_all_single_block(
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
-    """
-    Grouping a single block preserves it.
-    """
+    """Grouping a single block preserves it."""
     content = language.code_block_builder(code="x = []", language="python")
     test_document = tmp_path / "test"
     test_document.write_text(
@@ -100,9 +94,7 @@ def test_group_all_empty_document(
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
-    """
-    Empty documents do not raise errors.
-    """
+    """Empty documents do not raise errors."""
     content = "Empty document without code blocks."
     test_document = tmp_path / "test"
     test_document.write_text(
@@ -129,9 +121,7 @@ def test_group_all_empty_document(
 
 
 def test_group_all_no_pad(language: MarkupLanguage, tmp_path: Path) -> None:
-    """
-    Groups can be combined without inserting extra padding.
-    """
+    """Groups can be combined without inserting extra padding."""
     content = language.markup_separator.join(
         [
             language.code_block_builder(code="x = []", language="python"),
@@ -202,9 +192,7 @@ def test_thread_safety(language: MarkupLanguage, tmp_path: Path) -> None:
     examples: list[Example] = list(document.examples())
 
     def evaluate(ex: Example) -> None:
-        """
-        Evaluate the example.
-        """
+        """Evaluate the example."""
         ex.evaluate()
 
     with ThreadPoolExecutor(max_workers=4) as executor:
@@ -222,9 +210,7 @@ def test_group_all_with_skip(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Skip directives are honored when grouping code blocks.
-    """
+    """Skip directives are honored when grouping code blocks."""
     language, directive_builder = language_directive_builder
     skip_directive = directive_builder(directive="skip", argument="next")
     skipped_block = language.code_block_builder(
@@ -335,7 +321,8 @@ def test_state_cleanup_on_evaluator_failure(
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
-    """When an evaluator raises an exception, the group-all state is cleaned
+    """When an evaluator raises an exception, the group-all state is
+    cleaned
     up.
 
     This ensures that pop_evaluator is called even when the evaluator
@@ -420,9 +407,7 @@ def test_finalize_waits_for_code_blocks(
     # are collected, resulting in an empty or partial group.
     # With the fix, the finalize marker waits for all code blocks.
     def evaluate(ex: Example) -> None:
-        """
-        Evaluate the example.
-        """
+        """Evaluate the example."""
         ex.evaluate()
 
     # Run all three concurrently - finalize should wait for code blocks
@@ -473,9 +458,7 @@ def test_custom_parser_with_string_parsed_value(
     def custom_parser_with_string_parsed(
         document: Document,
     ) -> Iterable[Region]:
-        """
-        A parser that creates examples with string parsed values.
-        """
+        """A parser that creates examples with string parsed values."""
         # Find two positions in the document for our custom regions
         # We'll create regions that have source lexemes but string parsed
         # values
@@ -555,9 +538,7 @@ def test_examples_without_source_lexeme(
     # This simulates parsers that create examples which should not be
     # collected by the group-all parser.
     def custom_parser_without_source(document: Document) -> Iterable[Region]:
-        """
-        A parser that creates an example without a source lexeme.
-        """
+        """A parser that creates an example without a source lexeme."""
         # Place the region at the end of the document to avoid overlap
         # with the code block.
         doc_end = len(document.text)

--- a/tests/parsers/test_grouped_source.py
+++ b/tests/parsers/test_grouped_source.py
@@ -1,6 +1,4 @@
-"""
-Grouped source parser tests shared across markup languages.
-"""
+"""Grouped source parser tests shared across markup languages."""
 
 import subprocess
 from concurrent.futures import ThreadPoolExecutor
@@ -19,9 +17,7 @@ def test_group(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    The group parser groups examples.
-    """
+    """The group parser groups examples."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -76,9 +72,7 @@ def test_nothing_after_group(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Groups are handled even at the end of a document.
-    """
+    """Groups are handled even at the end of a document."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -126,9 +120,7 @@ def test_empty_group(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Empty groups are handled gracefully.
-    """
+    """Empty groups are handled gracefully."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -171,9 +163,7 @@ def test_group_with_skip(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Skip directives are respected within a group.
-    """
+    """Skip directives are respected within a group."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -221,9 +211,7 @@ def test_group_with_skip_range(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Skip start/end ranges are respected within a group.
-    """
+    """Skip start/end ranges are respected within a group."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -275,9 +263,7 @@ def test_no_argument(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    An error is raised when a group directive has no arguments.
-    """
+    """An error is raised when a group directive has no arguments."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -309,9 +295,7 @@ def test_malformed_argument(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    An error is raised when the group directive argument is invalid.
-    """
+    """An error is raised when the group directive argument is invalid."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -346,9 +330,7 @@ def test_end_only(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    An error is raised when an end directive has no matching start.
-    """
+    """An error is raised when an end directive has no matching start."""
     language, directive_builder = language_directive_builder
     content = directive_builder(directive="group", argument="end")
     test_document = tmp_path / "test"
@@ -376,9 +358,7 @@ def test_start_after_start(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    An error is raised when start directives are nested improperly.
-    """
+    """An error is raised when start directives are nested improperly."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -410,9 +390,7 @@ def test_start_only(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    An error is raised when a group starts but doesn't end.
-    """
+    """An error is raised when a group starts but doesn't end."""
     language, directive_builder = language_directive_builder
     content = directive_builder(directive="group", argument="start")
     test_document = tmp_path / "test"
@@ -439,9 +417,7 @@ def test_start_start_end(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    An error is raised when start directives are nested with an end.
-    """
+    """An error is raised when start directives are nested with an end."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -476,7 +452,8 @@ def test_directive_name_not_regex_escaped(
     tmp_path: Path,
 ) -> None:
     """
-    Directive names containing regex characters are matched literally.
+    Directive names containing regex characters are matched
+    literally.
     """
     language, directive_builder = language_directive_builder
     directive = "custom-group[has_square_brackets]"
@@ -533,9 +510,7 @@ def test_with_shell_command_evaluator(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    The group parser cooperates with the shell command evaluator.
-    """
+    """The group parser cooperates with the shell command evaluator."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -597,7 +572,8 @@ def test_state_cleanup_on_evaluator_failure(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """When an evaluator raises an exception, the grouper state is cleaned up.
+    """When an evaluator raises an exception, the grouper state is cleaned
+    up.
 
     This ensures that subsequent groups in the same document can be
     evaluated without getting misleading errors about mismatched
@@ -661,7 +637,8 @@ def test_thread_safety(
     tmp_path: Path,
 ) -> None:
     """
-    The group parser is thread-safe when examples are evaluated concurrently.
+    The group parser is thread-safe when examples are evaluated
+    concurrently.
     """
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
@@ -695,9 +672,7 @@ def test_thread_safety(
     examples: list[Example] = list(document.examples())
 
     def evaluate(ex: Example) -> None:
-        """
-        Evaluate the example.
-        """
+        """Evaluate the example."""
         ex.evaluate()
 
     with ThreadPoolExecutor(max_workers=4) as executor:
@@ -765,9 +740,7 @@ def test_multiple_groups_concurrent_evaluation(
     start2.evaluate()
 
     def evaluate(ex: Example) -> None:
-        """
-        Evaluate an example.
-        """
+        """Evaluate an example."""
         ex.evaluate()
 
     code_blocks = [code1a, code1b, code2a, code2b]
@@ -794,7 +767,8 @@ def test_evaluation_order_independence(
     tmp_path: Path,
 ) -> None:
     """
-    Examples can be evaluated out of order and still produce correct results.
+    Examples can be evaluated out of order and still produce correct
+    results.
     """
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
@@ -895,9 +869,7 @@ def test_no_pad_groups(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    It is possible to avoid padding grouped code blocks.
-    """
+    """It is possible to avoid padding grouped code blocks."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -1000,9 +972,7 @@ def test_end_marker_waits_for_code_blocks(
     # are collected, resulting in an empty or partial group.
     # With the fix, the end marker waits for all code blocks.
     def evaluate(ex: Example) -> None:
-        """
-        Evaluate the example.
-        """
+        """Evaluate the example."""
         ex.evaluate()
 
     # Run all three concurrently - end marker should wait for code blocks

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -1,6 +1,4 @@
-"""
-Tests for the languages module.
-"""
+"""Tests for the languages module."""
 
 from pathlib import Path
 
@@ -42,9 +40,7 @@ def test_code_block_parser(
     value: int,
     tmp_path: Path,
 ) -> None:
-    """
-    Test that each language's code block parser works correctly.
-    """
+    """Test that each language's code block parser works correctly."""
     code = f"x = {value}"
     content = language.code_block_builder(code=code, language="python")
     test_document = tmp_path / "test"
@@ -70,9 +66,7 @@ def test_skip_parser(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Test that each language's skip parser works correctly.
-    """
+    """Test that each language's skip parser works correctly."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -113,9 +107,7 @@ def test_skip_parser(
     ],
 )
 def test_code_block_empty(language: MarkupLanguage) -> None:
-    """
-    Code block builders handle empty content.
-    """
+    """Code block builders handle empty content."""
     block = language.code_block_builder(code="", language="python")
     assert block
 
@@ -124,9 +116,7 @@ def test_group_parser(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """
-    Test that each language's group parser works correctly.
-    """
+    """Test that each language's group parser works correctly."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
@@ -178,9 +168,7 @@ def test_sphinx_jinja_parser(
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
-    """
-    Test that each language's sphinx-jinja parser works correctly.
-    """
+    """Test that each language's sphinx-jinja parser works correctly."""
     assert language.sphinx_jinja_parser_cls is not None
     jinja_builder = language.jinja_block_builder
     assert jinja_builder is not None
@@ -202,7 +190,8 @@ def test_sphinx_jinja_parser(
 
 def test_markdown_no_sphinx_jinja() -> None:
     """
-    Test that Markdown-like formats do not have a sphinx-jinja parser.
+    Test that Markdown-like formats do not have a sphinx-jinja
+    parser.
     """
     for language in (MARKDOWN, MDX, DJOT, NORG):
         assert language.sphinx_jinja_parser_cls is None
@@ -210,9 +199,7 @@ def test_markdown_no_sphinx_jinja() -> None:
 
 
 def test_language_names() -> None:
-    """
-    Test that languages have the expected names.
-    """
+    """Test that languages have the expected names."""
     assert MYST.name == "MyST"
     assert RESTRUCTUREDTEXT.name == "reStructuredText"
     assert MARKDOWN.name == "Markdown"
@@ -222,9 +209,7 @@ def test_language_names() -> None:
 
 
 def test_mdx_code_block_attributes(tmp_path: Path) -> None:
-    """
-    MDX code block parsers expose attributes from the info line.
-    """
+    """MDX code block parsers expose attributes from the info line."""
     mdx_content = (
         '```python title="example.py" group="setup"\nvalue = 7\n```\n'
     )
@@ -253,7 +238,8 @@ def test_mdx_code_block_attributes(tmp_path: Path) -> None:
 
 def test_mdx_info_line_at_eof_without_newline() -> None:
     """
-    An MDX code block info line at EOF without trailing newline is recognized.
+    An MDX code block info line at EOF without trailing newline is
+    recognized.
     """
     parser = MDX.code_block_parser_cls(language="python")
     document = Document(text="```python", path="doc.mdx")


### PR DESCRIPTION
Replace docformatter with pydocstringformatter.

This follows the same pattern as https://github.com/VWS-Python/vws-python/pull/2793.

Changes:
- Replace `docformatter==1.7.7` with `pydocstringformatter==0.7.3`
- Update tool configuration in pyproject.toml
- Update ruff ignore rules (D200 → D205, D212)
- Format docstrings with new tool
- Workaround URL breaking issue by isolating URLs on their own lines where needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Tooling change and docstring reformat**
> 
> - Replace `docformatter` with `pydocstringformatter` in dev deps and pre-commit; add `[tool.pydocstringformatter]` config and remove `[tool.docformatter]`
> - Adjust Ruff rules (docstring checks) and per-file ignores to align with new formatter
> - Update pre-commit hook definitions and CI skip list accordingly
> - Reformat docstrings across `src/` and `tests/` to new style (one-line summaries, wrapping), with no functional code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8228776cef66fe35dfdea3851b1a7c77f2dcfa3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->