### PR TITLE
Remove --example-workers 0 due to mypy bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,8 +118,8 @@ repos:
 
       - id: shellcheck-docs
         name: shellcheck-docs
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=shell
-          --language=console --command="uv run --extra=dev shellcheck --shell=bash"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=shell --language=console
+          --command="uv run --extra=dev shellcheck --shell=bash"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -155,8 +155,8 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev mypy"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev mypy"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -181,8 +181,8 @@ repos:
       - id: pyright-docs
         name: pyright-docs
         stages: [pre-push]
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev pyright"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev pyright"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -198,8 +198,8 @@ repos:
 
       - id: vulture-docs
         name: vulture docs
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev vulture"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev vulture"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -232,8 +232,8 @@ repos:
 
       - id: pylint-docs
         name: pylint-docs
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev pylint"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev pylint"
         language: python
         stages: [manual]
         types_or: [markdown, rst]
@@ -260,8 +260,8 @@ repos:
       - id: ty-docs
         name: ty-docs
         stages: [pre-push]
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev ty check"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev ty check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -318,8 +318,8 @@ repos:
 
       - id: interrogate-docs
         name: interrogate docs
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev interrogate"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev interrogate"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]
@@ -371,8 +371,8 @@ repos:
       - id: pyrefly-docs
         name: pyrefly-docs
         stages: [pre-push]
-        entry: uvx --python=3.13 doccmd --no-write-to-file --example-workers 0 --language=python
-          --command="uv run --extra=dev pyrefly check"
+        entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
+          run --extra=dev pyrefly check"
         language: python
         types_or: [markdown, rst]
         additional_dependencies: [uv==0.9.5]


### PR DESCRIPTION
This removes `--example-workers 0` from the pre-commit config due to a mypy race condition bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts pre-commit docs hooks to avoid `doccmd` example worker usage, addressing a mypy race condition.
> 
> - Updates `.pre-commit-config.yaml` to drop `--example-workers 0` from `doccmd` for `shellcheck-docs`, `mypy-docs`, `pyright-docs`, `vulture-docs`, `pylint-docs`, `ty-docs`, `interrogate-docs`, and `pyrefly-docs`
> - Minor formatting reflow of long `entry` lines; no code changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1a91c48e67e9a82e86d1f677abbe78f5bb9e848. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->