### PR TITLE
Fix: Remove --example-workers 0 only from mypy-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -152,6 +152,7 @@ repos:
         pass_filenames: false
         additional_dependencies: [uv==0.9.5]
 
+      # We do not use --example-workers 0 due to https://github.com/python/mypy/issues/18283
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]


### PR DESCRIPTION
The previous PR incorrectly removed `--example-workers 0` from all hooks.

This PR reverts that and correctly removes it only from the `mypy-docs` hook, which is the one affected by the mypy bug.

See https://github.com/python/mypy/issues/18283

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts doccmd executions in `.pre-commit-config.yaml` to stabilize docs linting/type checks.
> 
> - Re-adds `--example-workers 0` to `shellcheck-docs`, `pyright-docs`, `vulture-docs`, `pylint-docs`, `ty-docs`, `interrogate-docs`, and `pyrefly-docs`
> - Leaves `mypy-docs` without `--example-workers 0` (documented via inline comment) due to mypy issue 18283
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3932d12521abff6d64d8af16107743c8f6726577. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->