### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         platform: [ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.platform }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = [
     "version",
@@ -300,7 +301,7 @@ pep621_dev_dependency_groups = [
 [tool.pyproject-fmt]
 indent = 4
 keep_full_version = true
-max_supported_python = "3.13"
+max_supported_python = "3.14"
 
 [tool.pytest.ini_options]
 


### PR DESCRIPTION
Add Python 3.14 to the test matrix and classifiers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds declared and tested support for Python 3.14.
> 
> - Extends CI matrix in `.github/workflows/ci.yml` to include `python-version` `3.14`
> - Updates `pyproject.toml` classifiers to add `"Programming Language :: Python :: 3.14"`
> - Bumps `[tool.pyproject-fmt]` `max_supported_python` to `"3.14"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50984dbc5b7beda8cd0854ce47a67738f34904d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->