### PR TITLE
Add ty error-on-warning configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -336,6 +336,12 @@ reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 exclude = [ "build", ".venv" ]
 
+[tool.ty.analysis]
+respect-type-ignore-comments = false
+
+[tool.ty.terminal]
+error-on-warning = true
+
 [tool.pydocstringformatter]
 write = true
 split-summary-body = false


### PR DESCRIPTION
Add ty configuration:
- respect-type-ignore-comments = false (for mypy compatibility)
- error-on-warning = true

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures `ty` in `pyproject.toml`.
> 
> - Adds `tool.ty.analysis` with `respect-type-ignore-comments = false` (aligns with mypy behavior)
> - Adds `tool.ty.terminal` with `error-on-warning = true` to fail on warnings
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit beb70e8b672df70cc521e1710a1b394c10ada4fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->