### PR TITLE
Bump pyproject-fmt to 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,23 +56,23 @@ optional-dependencies.dev = [
     "pydocstyle==6.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.12.1",
+    "pyproject-fmt==2.14.0",
     "pyrefly==0.51.1",
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
     "ruff==0.14.14",
-    # We add shellcheck-py not only for shell scripts and shell code blocks,
-    # but also because having it installed means that ``actionlint-py`` will
-    # use it to lint shell commands in GitHub workflow files.
-    "shellcheck-py==0.11.0.1",
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "sybil==9.3.0",
     "ty==0.0.15",
     "uv==0.10.0",
     "vulture==2.14",
+    # We add shellcheck-py not only for shell scripts and shell code blocks,
+    # but also because having it installed means that ``actionlint-py`` will
+    # use it to lint shell commands in GitHub workflow files.
+    "shellcheck-py==0.11.0.1",
     "yamlfix==1.19.1",
     "zizmor==1.22.0",
 ]
@@ -81,57 +81,49 @@ urls.Source = "https://github.com/adamtheturtle/sybil-extras"
 
 [tool.setuptools]
 zip-safe = false
-
-[tool.setuptools.package-data]
-sybil_extras = [
+package-data.sybil_extras = [
     "py.typed",
 ]
-
-[tool.setuptools.packages.find]
-where = [
+packages.find.where = [
     "src",
 ]
 
-[tool.distutils.bdist_wheel]
-universal = true
+[tool.distutils]
+bdist_wheel.universal = true
 
 [tool.setuptools_scm]
 
 [tool.ruff]
 line-length = 79
-
 lint.select = [
     "ALL",
 ]
 lint.ignore = [
-    # We are happy to manage our own 'complexity'.
-    "C901",
-    # Ruff warns that this conflicts with the formatter.
-    "COM812",
     # Allow our chosen docstring line-style - pydocstringformatter handles formatting
     # but doesn't enforce D205 (blank line after summary) or D212 (summary on first line).
     "D205",
-    "D212",
-    # Ruff warns that this conflicts with the formatter.
-    "ISC001",
     # Ignore 'too-many-*' errors as they seem to get in the way more than
     # helping.
     "PLR0913",
+    # Ruff warns that this conflicts with the formatter.
+    "COM812",
+    # Ruff warns that this conflicts with the formatter.
+    "ISC001",
+    # We are happy to manage our own 'complexity'.
+    "C901",
+    "D212",
 ]
-
 lint.per-file-ignores."doccmd_*.py" = [
+    # Allow 'assert' in docs.
+    "S101",
     # Allow our chosen docstring line-style - pydocstringformatter handles
     # formatting but docstrings in docs may not match this style.
     "D200",
-    # Allow 'assert' in docs.
-    "S101",
 ]
-
 lint.per-file-ignores."tests/**/test_*.py" = [
     # Allow 'assert' as we use it for tests.
     "S101",
 ]
-
 # Do not automatically remove commented out code.
 # We comment out code during development, and with VSCode auto-save, this code
 # is sometimes annoyingly removed.
@@ -141,21 +133,13 @@ lint.unfixable = [
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
-
-[tool.pylint.'FORMAT']
-
 # Allow the body of an if to be on the same line as the test if there is no
 # else.
-single-line-if-stmt = false
-
-[tool.pylint.'MASTER']
-
+"FORMAT".single-line-if-stmt = false
 # Pickle collected data for later comparisons.
-persistent = true
-
+"MASTER".persistent = true
 # Use multiple processes to speed up Pylint.
-jobs = 0
-
+"MASTER".jobs = 0
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
 # See https://chezsoi.org/lucas/blog/pylint-strict-base-configuration.html.
@@ -164,7 +148,7 @@ jobs = 0
 # - pylint.extensions.magic_value
 # - pylint.extensions.while_used
 # as they seemed to get in the way.
-load-plugins = [
+"MASTER".load-plugins = [
     "pylint_per_file_ignores",
     "pylint.extensions.bad_builtin",
     "pylint.extensions.comparison_placement",
@@ -182,18 +166,14 @@ load-plugins = [
     "pylint.extensions.set_membership",
     "pylint.extensions.typing",
 ]
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
-unsafe-load-any-extension = false
-
-[tool.pylint.'MESSAGES CONTROL']
-
+"MASTER".unsafe-load-any-extension = false
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable = [
+"MESSAGES CONTROL".enable = [
     "bad-inline-option",
     "deprecated-pragma",
     "file-ignored",
@@ -201,7 +181,6 @@ enable = [
     "use-symbolic-message-instead",
     "useless-suppression",
 ]
-
 # Disable the message, report, category or checker with the given id(s). You
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
@@ -211,8 +190,7 @@ enable = [
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-
-disable = [
+"MESSAGES CONTROL".disable = [
     "too-few-public-methods",
     "too-many-locals",
     "too-many-arguments",
@@ -236,32 +214,25 @@ disable = [
     # mypy does not want untyped parameters.
     "useless-type-doc",
 ]
-
 # We ignore invalid names because:
 # - We want to use generated module names, which may not be valid, but are never seen.
 # - We want to use global variables in documentation, which may not be uppercase.
 # - conf.py is a Sphinx configuration file which requires lowercase global variable names.
-per-file-ignores = [
+"MESSAGES CONTROL".per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
 ]
-
-[tool.pylint.'SPELLING']
-
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.
-spelling-dict = 'en_US'
-
+"SPELLING".spelling-dict = "en_US"
 # A path to a file that contains private dictionary; one word per line.
-spelling-private-dict-file = 'spelling_private_dict.txt'
-
+"SPELLING".spelling-private-dict-file = "spelling_private_dict.txt"
 # Tells whether to store unknown words to indicated private dictionary in
 # --spelling-private-dict-file option instead of raising a message.
-spelling-store-unknown-words = 'no'
+"SPELLING".spelling-store-unknown-words = "no"
 
 [tool.check-manifest]
-
 ignore = [
     ".checkmake-config.ini",
     ".prettierrc",
@@ -303,24 +274,18 @@ indent = 4
 keep_full_version = true
 max_supported_python = "3.14"
 
-[tool.pytest.ini_options]
+[tool.pytest]
+ini_options.xfail_strict = true
+ini_options.log_cli = true
 
-xfail_strict = true
-log_cli = true
-
-[tool.coverage.report]
-
-exclude_also = [
+[tool.coverage]
+report.exclude_also = [
     "if TYPE_CHECKING:",
     "class .*\\bProtocol\\):",
 ]
-
-[tool.coverage.run]
-
-branch = true
+run.branch = true
 
 [tool.mypy]
-
 strict = true
 files = [ "." ]
 exclude = [ "build" ]
@@ -330,17 +295,14 @@ plugins = [
 ]
 
 [tool.pyright]
-
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
 typeCheckingMode = "strict"
 exclude = [ "build", ".venv" ]
 
-[tool.ty.analysis]
-respect-type-ignore-comments = false
-
-[tool.ty.terminal]
-error-on-warning = true
+[tool.ty]
+analysis.respect-type-ignore-comments = false
+terminal.error-on-warning = true
 
 [tool.pydocstringformatter]
 write = true
@@ -354,7 +316,6 @@ omit-covered-files = true
 verbose = 2
 
 [tool.doc8]
-
 max_line_length = 2000
 ignore_path = [
     "./.eggs",
@@ -402,11 +363,9 @@ ignore_names = [
     "templates_path",
     "warning_is_error",
 ]
-
 # Duplicate some of .gitignore
 exclude = [ ".venv" ]
 
 [tool.yamlfix]
-
 section_whitelines = 1
 whitelines = 1


### PR DESCRIPTION
## Summary
- Work around tox-dev/toml-fmt#184 (double quotes in comments corrupt arrays) and tox-dev/toml-fmt#186 (single-quoted strings in arrays with comments get corrupted) by adjusting quote style
- Bump pyproject-fmt from the current version to 2.14.0
- Apply new formatting from pyproject-fmt 2.14.0

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change plus a dev-tool version bump; no runtime code paths are modified.
> 
> **Overview**
> Bumps the dev dependency `pyproject-fmt` from `2.12.1` to `2.14.0`.
> 
> Reformats `pyproject.toml` to match the updated formatter output and work around quoting/comment formatting issues, including reorganizing several tool tables (e.g. `setuptools`, `distutils`, `pytest`, `coverage`, `ty`, `pylint`) into dotted-key style and adjusting string quoting in arrays/comments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a9cc608e103119979e7f5fb71a252bd136836e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->