### PR TITLE
Bump ruff from 0.14.14 to 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.dev = [
     "pyroma==5.0.1",
     "pytest==9.0.2",
     "pytest-cov==7.0.0",
-    "ruff==0.14.14",
+    "ruff==0.15.0",
     "shfmt-py==3.12.0.2",
     "sphinx-lint==1.0.2",
     "sybil==9.3.0",

--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -74,7 +74,7 @@ def _get_modified_region_text(
     Get the region text to use after the example content is
     replaced.
     """
-    first_line = original_region_text.split(sep="\n")[0]
+    first_line = original_region_text.split(maxsplit=1, sep="\n")[0]
     code_block_indent_prefix = first_line[
         : len(first_line) - len(first_line.lstrip())
     ]


### PR DESCRIPTION
## Summary
- Bumps ruff from 0.14.14 to 0.15.0
- Applies auto-fix for the newly stabilized `missing-maxsplit-arg` (`PLC0207`) rule which caused CI to fail on #731

Closes #731

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a dev-dependency bump plus a small, behavior-preserving string-splitting change; low likelihood of runtime impact outside code-block rewriting edge cases.
> 
> **Overview**
> Updates dev tooling by bumping `ruff` from `0.14.14` to `0.15.0`.
> 
> Applies the new Ruff `missing-maxsplit-arg` lint fix in `code_block_writer._get_modified_region_text` by adding `maxsplit=1` to the newline `split`, avoiding unintended extra splitting and restoring CI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b126286373160369ea328bfaf03aec149baedc57. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->