### PR TITLE
Update pyproject-fmt to 2.15.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ optional-dependencies.dev = [
     "pydocstyle==6.3",
     "pylint[spelling]==4.0.4",
     "pylint-per-file-ignores==3.2.0",
-    "pyproject-fmt==2.14.2",
+    "pyproject-fmt==2.15.2",
     "pyrefly==0.52.0",
     "pyright==1.1.408",
     "pyroma==5.0.1",
@@ -279,11 +279,11 @@ ini_options.xfail_strict = true
 ini_options.log_cli = true
 
 [tool.coverage]
-report.exclude_also = [
-    "if TYPE_CHECKING:",
-    "class .*\\bProtocol\\):",
-]
 run.branch = true
+report.exclude_also = [
+    "class .*\\bProtocol\\):",
+    "if TYPE_CHECKING:",
+]
 
 [tool.mypy]
 strict = true


### PR DESCRIPTION
Update pyproject-fmt to 2.15.2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev tooling/version bump and a config reordering in `pyproject.toml` with no runtime or behavior changes expected.
> 
> **Overview**
> Updates the dev tooling dependency `pyproject-fmt` from `2.14.2` to `2.15.2`.
> 
> Also makes a small reordering/formatting adjustment in `[tool.coverage]` (moves `run.branch = true` and reorders `report.exclude_also` entries) without changing the effective coverage settings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d7098db4108186f3330b4b2eb4e58994e2587ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->