### PR TITLE
Add pyrefly non-exhaustive match as error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -294,6 +294,9 @@ plugins = [
     "mypy_strict_kwargs",
 ]
 
+[tool.pyrefly]
+errors.non-exhaustive-match = "error"
+
 [tool.pyright]
 enableTypeIgnoreComments = false
 reportUnnecessaryTypeIgnoreComment = true
@@ -369,6 +372,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[tool.pyrefly]
-errors.non-exhaustive-match = "error"


### PR DESCRIPTION
Adds \ to \ in project \ files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only change that may cause CI/lint to fail on additional findings; no runtime behavior changes.
> 
> **Overview**
> Adds a `pyrefly` configuration block in `pyproject.toml` to treat *non-exhaustive match* findings as **errors**, tightening static analysis/linting enforcement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b18435b0ae2b446fc32cae8072c7d81f7ce910e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->