### PR TITLE
Enable coverage report.show_missing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -284,8 +284,8 @@ report.exclude_also = [
     "class .*\\bProtocol\\):",
     "if TYPE_CHECKING:",
 ]
-
 report.show_missing = true
+
 [tool.mypy]
 strict = true
 files = [ "." ]


### PR DESCRIPTION
Summary: set [tool.coverage] report.show_missing = true in pyproject.toml.\n\nTesting: not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration toggle affecting only test/coverage report output, with no runtime or security impact.
> 
> **Overview**
> Enables `coverage.py`’s `report.show_missing` setting in `pyproject.toml`, so coverage reports will explicitly list uncovered lines when generating the report.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33268cf947db170fd74f42462cd4baeda0f573d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->