### PR TITLE
Add missing @beartype decorators

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -57,6 +57,7 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
     return non_skip_count - skipped_count
 
 
+@beartype
 def _get_text(parsed: Lexeme | str) -> str:
     """Get text from a parsed value, which may be a Lexeme or a string.
 

--- a/src/sybil_extras/parsers/djot/codeblock.py
+++ b/src/sybil_extras/parsers/djot/codeblock.py
@@ -61,6 +61,7 @@ def _find_container_end(
     return default_end
 
 
+@beartype
 class DjotRawFencedCodeBlockLexer:
     """
     A lexer for Djot fenced code blocks that respects block quote
@@ -165,6 +166,7 @@ class DjotRawFencedCodeBlockLexer:
                 index = opening.end()
 
 
+@beartype
 class DjotFencedCodeBlockLexer(DjotRawFencedCodeBlockLexer):
     """A lexer for Djot fenced code blocks that captures languages."""
 

--- a/src/sybil_extras/parsers/mdx/lexers.py
+++ b/src/sybil_extras/parsers/mdx/lexers.py
@@ -2,6 +2,7 @@
 
 import re
 
+from beartype import beartype
 from sybil.parsers.abstract.lexers import BlockLexer
 
 DIRECTIVE_IN_JSX_COMMENT_START = (
@@ -12,6 +13,7 @@ DIRECTIVE_IN_JSX_COMMENT_START = (
 DIRECTIVE_IN_JSX_COMMENT_END = r"(?:(?<=\n){prefix})?\*/\}}"
 
 
+@beartype
 class DirectiveInJSXCommentLexer(BlockLexer):
     """A lexer for faux directives in JSX-style comments.
 

--- a/src/sybil_extras/parsers/norg/codeblock.py
+++ b/src/sybil_extras/parsers/norg/codeblock.py
@@ -11,6 +11,7 @@ from sybil.region import Lexeme
 from sybil.typing import Evaluator, Lexer
 
 
+@beartype
 class NorgVerbatimRangedTagLexer:
     """A lexer for Norg verbatim ranged tags.
 


### PR DESCRIPTION
## Summary
- Add @beartype decorator to classes and functions with type annotations that were missing runtime type checking
- Covers DjotRawFencedCodeBlockLexer, DjotFencedCodeBlockLexer, NorgVerbatimRangedTagLexer, DirectiveInJSXCommentLexer, and _get_text

## Test plan
- [ ] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Decorator-only change that primarily affects runtime validation; risk is limited to surfacing new type errors at runtime in these parser entry points.
> 
> **Overview**
> Adds `@beartype` runtime type checking to previously-annotated but undecorated code in the parsers: `_get_text` in `_grouping_utils.py`, Djot lexers `DjotRawFencedCodeBlockLexer`/`DjotFencedCodeBlockLexer`, MDX `DirectiveInJSXCommentLexer` (including importing `beartype`), and Norg `NorgVerbatimRangedTagLexer`.
> 
> No parsing logic changes are introduced; the only behavioral impact is potential `beartype` runtime exceptions if callers pass values that violate the type hints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93e53e2c7854c63d2b79f3c7b1c35de7f9d15c13. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->