### PR TITLE
Enforce keyword-only arguments

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -66,6 +66,7 @@ def _get_within_code_block_indentation_prefix(example: Example) -> str:
 
 @beartype
 def _get_modified_region_text(
+    *,
     example: Example,
     original_region_text: str,
     new_code_block_content: str,

--- a/src/sybil_extras/evaluators/shell_evaluator.py
+++ b/src/sybil_extras/evaluators/shell_evaluator.py
@@ -80,6 +80,7 @@ def _run_command(
 
     @beartype
     def _process_stream(
+        *,
         stream_fileno: int,
         output: IO[bytes] | BytesIO,
     ) -> None:
@@ -139,11 +140,17 @@ def _run_command(
 
             stdout_thread = threading.Thread(
                 target=_process_stream,
-                args=(process.stdout.fileno(), sys.stdout.buffer),
+                kwargs={
+                    "stream_fileno": process.stdout.fileno(),
+                    "output": sys.stdout.buffer,
+                },
             )
             stderr_thread = threading.Thread(
                 target=_process_stream,
-                args=(process.stderr.fileno(), sys.stderr.buffer),
+                kwargs={
+                    "stream_fileno": process.stderr.fileno(),
+                    "output": sys.stderr.buffer,
+                },
             )
 
             stdout_thread.start()
@@ -183,7 +190,7 @@ def _count_leading_newlines(s: str) -> int:
 
 
 @beartype
-def _lstrip_newlines(input_string: str, number_of_newlines: int) -> str:
+def _lstrip_newlines(*, input_string: str, number_of_newlines: int) -> str:
     """Removes a specified number of newlines from the start of the string.
 
     Args:

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -163,6 +163,7 @@ def create_combined_region(
 
 @beartype
 def create_combined_example(
+    *,
     examples: Sequence[Example],
     region: Region,
 ) -> Example:

--- a/src/sybil_extras/parsers/abstract/group_all.py
+++ b/src/sybil_extras/parsers/abstract/group_all.py
@@ -63,6 +63,7 @@ class _GroupAllEvaluator:
 
     def register_document(
         self,
+        *,
         document: Document,
         expected_code_blocks: int,
     ) -> None:

--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -150,6 +150,7 @@ class _Grouper:
 
     def _find_containing_group_and_state(
         self,
+        *,
         document: Document,
         position: int,
     ) -> _GroupState | None:
@@ -174,6 +175,7 @@ class _Grouper:
 
     def _get_group_state(
         self,
+        *,
         document: Document,
         group_id: int,
     ) -> _GroupState:
@@ -184,6 +186,7 @@ class _Grouper:
 
     def _cleanup_group_state(
         self,
+        *,
         document: Document,
         group_id: int,
     ) -> None:

--- a/src/sybil_extras/parsers/djot/codeblock.py
+++ b/src/sybil_extras/parsers/djot/codeblock.py
@@ -69,6 +69,7 @@ class DjotRawFencedCodeBlockLexer:
 
     def __init__(
         self,
+        *,
         info_pattern: Pattern[str] = re.compile(
             pattern=r"$\n", flags=re.MULTILINE
         ),
@@ -80,6 +81,7 @@ class DjotRawFencedCodeBlockLexer:
 
     def make_region(
         self,
+        *,
         opening: Match[str],
         document: Document,
         closing: Match[str] | None,
@@ -169,7 +171,7 @@ class DjotFencedCodeBlockLexer(DjotRawFencedCodeBlockLexer):
     """A lexer for Djot fenced code blocks that captures languages."""
 
     def __init__(
-        self, language: str, mapping: dict[str, str] | None = None
+        self, *, language: str, mapping: dict[str, str] | None = None
     ) -> None:
         """Initialize the lexer."""
         super().__init__(

--- a/src/sybil_extras/parsers/djot/lexers.py
+++ b/src/sybil_extras/parsers/djot/lexers.py
@@ -30,6 +30,7 @@ class DirectiveInDjotCommentLexer:
 
     def __init__(
         self,
+        *,
         directive: str,
         arguments: str = r".*?",
         mapping: dict[str, str] | None = None,

--- a/src/sybil_extras/parsers/markdown_it/codeblock.py
+++ b/src/sybil_extras/parsers/markdown_it/codeblock.py
@@ -35,6 +35,7 @@ class CodeBlockParser:
 
     def __init__(
         self,
+        *,
         language: str | None = None,
         evaluator: Evaluator | None = None,
     ) -> None:

--- a/src/sybil_extras/parsers/markdown_it/lexers.py
+++ b/src/sybil_extras/parsers/markdown_it/lexers.py
@@ -36,6 +36,7 @@ class DirectiveInHTMLCommentLexer:
 
     def __init__(
         self,
+        *,
         directive: str,
         arguments: str = ".*?",
     ) -> None:

--- a/src/sybil_extras/parsers/mdx/lexers.py
+++ b/src/sybil_extras/parsers/mdx/lexers.py
@@ -40,6 +40,7 @@ class DirectiveInJSXCommentLexer(BlockLexer):
 
     def __init__(
         self,
+        *,
         directive: str,
         arguments: str = ".*?",
         mapping: dict[str, str] | None = None,

--- a/src/sybil_extras/parsers/norg/codeblock.py
+++ b/src/sybil_extras/parsers/norg/codeblock.py
@@ -27,6 +27,7 @@ class NorgVerbatimRangedTagLexer:
 
     def __init__(
         self,
+        *,
         language: str,
         mapping: dict[str, str] | None = None,
     ) -> None:

--- a/src/sybil_extras/parsers/norg/lexers.py
+++ b/src/sybil_extras/parsers/norg/lexers.py
@@ -30,6 +30,7 @@ class DirectiveInNorgCommentLexer:
 
     def __init__(
         self,
+        *,
         directive: str,
         arguments: str = r".*?",
         mapping: dict[str, str] | None = None,


### PR DESCRIPTION
## Summary
- Add * separator to enforce keyword-only arguments in functions and methods with 2+ parameters
- Update all call sites to use keyword arguments
- Covers parsers, evaluators, and utility functions

## Test plan
- [ ] Run existing test suite to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly mechanical API tightening, but it changes many function/method signatures across parsing/evaluation code and can break downstream or missed internal call sites at runtime.
> 
> **Overview**
> Enforces keyword-only arguments (adds `*`) across multiple evaluators, grouping utilities, and parser/lexer constructors, including Djot/MarkdownIt/MDX/Norg components.
> 
> Updates call sites accordingly (e.g., switches `threading.Thread` stream processing to `kwargs=` and adjusts helper invocations like `_lstrip_newlines`/`create_combined_example`) to match the new signatures, with no intended functional behavior change beyond stricter calling conventions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9dffbe04d87a11131bcf903935470b6936552c5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->