### PR TITLE
Use keyword-only parameters in tests

### DIFF
--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -21,6 +21,7 @@ from sybil_extras.languages import (
 
 
 def test_writes_modified_content(
+    *,
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
@@ -192,6 +193,7 @@ def test_writes_on_evaluator_exception(tmp_path: Path) -> None:
 
 
 def test_empty_code_block_write_content(
+    *,
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
@@ -329,6 +331,7 @@ def test_empty_code_block_write_content(
 
 
 def test_empty_code_block_with_options(
+    *,
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
@@ -450,6 +453,7 @@ def test_empty_code_block_with_options(
     ],
 )
 def test_empty_code_block_write_empty(
+    *,
     tmp_path: Path,
     new_content: str,
 ) -> None:
@@ -693,6 +697,7 @@ def test_encoding_parameter(tmp_path: Path) -> None:
 
 
 def test_indented_existing_block(
+    *,
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:
@@ -816,6 +821,7 @@ def test_indented_existing_block(
 
 
 def test_indented_empty_existing_block(
+    *,
     tmp_path: Path,
     markup_language: MarkupLanguage,
 ) -> None:

--- a/tests/evaluators/test_multi.py
+++ b/tests/evaluators/test_multi.py
@@ -84,6 +84,7 @@ def test_multi_evaluator_raises_on_failure(rst_file: Path) -> None:
     ids=["non-empty", "empty"],
 )
 def test_multi_evaluator_propagates_failure_string(
+    *,
     rst_file: Path,
     failure_string: str,
 ) -> None:

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -377,8 +377,8 @@ def test_pad(*, rst_file: Path, tmp_path: Path, use_pty_option: bool) -> None:
 
 @pytest.mark.parametrize(argnames="write_to_file", argvalues=[True, False])
 def test_write_to_file_new_content_trailing_newlines(
-    tmp_path: Path,
     *,
+    tmp_path: Path,
     write_to_file: bool,
     use_pty_option: bool,
     markup_language: MarkupLanguage,
@@ -519,8 +519,8 @@ def test_write_to_file_new_content_trailing_newlines(
 
 @pytest.mark.parametrize(argnames="write_to_file", argvalues=[True, False])
 def test_write_to_file_new_content_no_trailing_newlines(
-    tmp_path: Path,
     *,
+    tmp_path: Path,
     write_to_file: bool,
     use_pty_option: bool,
     markup_language: MarkupLanguage,
@@ -713,6 +713,7 @@ def test_non_utf8_output(
 
 
 def test_no_file_left_behind_on_interruption(
+    *,
     rst_file: Path,
     tmp_path: Path,
 ) -> None:
@@ -1073,6 +1074,7 @@ def test_custom_on_modify_with_modification(
     ids=["markdown_it", "sybil_markdown"],
 )
 def test_markdown_code_block_line_number(
+    *,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
     parser_cls: type,

--- a/tests/parsers/test_custom_directive_skip.py
+++ b/tests/parsers/test_custom_directive_skip.py
@@ -11,6 +11,7 @@ from sybil_extras.languages import DirectiveBuilder, MarkupLanguage
 
 
 def test_skip(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -80,6 +81,7 @@ def test_skip(
 
 
 def test_directive_name_in_evaluate_error(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -108,6 +110,7 @@ def test_directive_name_in_evaluate_error(
 
 
 def test_directive_name_in_parse_error(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -134,6 +137,7 @@ def test_directive_name_in_parse_error(
 
 
 def test_directive_name_not_regex_escaped(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -26,7 +26,7 @@ def make_temp_file_path(*, example: Example) -> Path:
     return Path(example.path).parent / f"temp_{uuid.uuid4().hex[:8]}.py"
 
 
-def test_group_all(language: MarkupLanguage, tmp_path: Path) -> None:
+def test_group_all(*, language: MarkupLanguage, tmp_path: Path) -> None:
     """All code blocks are grouped into a single block."""
     content = language.markup_separator.join(
         [
@@ -67,6 +67,7 @@ def test_group_all(language: MarkupLanguage, tmp_path: Path) -> None:
 
 
 def test_group_all_single_block(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
@@ -99,6 +100,7 @@ def test_group_all_single_block(
 
 
 def test_group_all_empty_document(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
@@ -128,7 +130,7 @@ def test_group_all_empty_document(
         example.evaluate()
 
 
-def test_group_all_no_pad(language: MarkupLanguage, tmp_path: Path) -> None:
+def test_group_all_no_pad(*, language: MarkupLanguage, tmp_path: Path) -> None:
     """Groups can be combined without inserting extra padding."""
     content = language.markup_separator.join(
         [
@@ -166,7 +168,7 @@ def test_group_all_no_pad(language: MarkupLanguage, tmp_path: Path) -> None:
     assert document.namespace["blocks"] == [expected]
 
 
-def test_thread_safety(language: MarkupLanguage, tmp_path: Path) -> None:
+def test_thread_safety(*, language: MarkupLanguage, tmp_path: Path) -> None:
     """
     The group-all parser is thread-safe when examples are evaluated
     concurrently.
@@ -215,6 +217,7 @@ def test_thread_safety(language: MarkupLanguage, tmp_path: Path) -> None:
 
 
 def test_group_all_with_skip(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -270,6 +273,7 @@ def test_group_all_with_skip(
 
 
 def test_evaluation_order_independence(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
@@ -326,6 +330,7 @@ def test_evaluation_order_independence(
 
 
 def test_state_cleanup_on_evaluator_failure(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
@@ -373,6 +378,7 @@ def test_state_cleanup_on_evaluator_failure(
 
 
 def test_finalize_waits_for_code_blocks(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
@@ -434,6 +440,7 @@ def test_finalize_waits_for_code_blocks(
 
 
 def test_custom_parser_with_string_parsed_value(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
@@ -512,6 +519,7 @@ def test_custom_parser_with_string_parsed_value(
 
 
 def test_examples_without_source_lexeme(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:

--- a/tests/parsers/test_grouped_source.py
+++ b/tests/parsers/test_grouped_source.py
@@ -22,6 +22,7 @@ def make_temp_file_path(*, example: Example) -> Path:
 
 
 def test_group(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -77,6 +78,7 @@ def test_group(
 
 
 def test_nothing_after_group(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -125,6 +127,7 @@ def test_nothing_after_group(
 
 
 def test_empty_group(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -168,6 +171,7 @@ def test_empty_group(
 
 
 def test_group_with_skip(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -216,6 +220,7 @@ def test_group_with_skip(
 
 
 def test_group_with_skip_range(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -268,6 +273,7 @@ def test_group_with_skip_range(
 
 
 def test_no_argument(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -300,6 +306,7 @@ def test_no_argument(
 
 
 def test_malformed_argument(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -335,6 +342,7 @@ def test_malformed_argument(
 
 
 def test_end_only(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -363,6 +371,7 @@ def test_end_only(
 
 
 def test_start_after_start(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -395,6 +404,7 @@ def test_start_after_start(
 
 
 def test_start_only(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -422,6 +432,7 @@ def test_start_only(
 
 
 def test_start_start_end(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -456,6 +467,7 @@ def test_start_start_end(
 
 
 def test_directive_name_not_regex_escaped(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -515,6 +527,7 @@ def test_directive_name_not_regex_escaped(
 
 
 def test_with_shell_command_evaluator(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -578,6 +591,7 @@ def test_with_shell_command_evaluator(
 
 
 def test_state_cleanup_on_evaluator_failure(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -643,6 +657,7 @@ def test_state_cleanup_on_evaluator_failure(
 
 
 def test_thread_safety(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -698,6 +713,7 @@ def test_thread_safety(
 
 
 def test_multiple_groups_concurrent_evaluation(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -773,6 +789,7 @@ def test_multiple_groups_concurrent_evaluation(
 
 
 def test_evaluation_order_independence(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -830,6 +847,7 @@ def test_evaluation_order_independence(
 
 
 def test_no_group_directives(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -876,6 +894,7 @@ def test_no_group_directives(
 
 
 def test_no_pad_groups(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -933,6 +952,7 @@ def test_no_pad_groups(
 
 
 def test_end_marker_waits_for_code_blocks(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -36,6 +36,7 @@ from sybil_extras.languages import (
     ],
 )
 def test_code_block_parser(
+    *,
     language: MarkupLanguage,
     value: int,
     tmp_path: Path,
@@ -63,6 +64,7 @@ def test_code_block_parser(
 
 
 def test_skip_parser(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -113,6 +115,7 @@ def test_code_block_empty(language: MarkupLanguage) -> None:
 
 
 def test_group_parser(
+    *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
@@ -165,6 +168,7 @@ def test_group_parser(
     ],
 )
 def test_sphinx_jinja_parser(
+    *,
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- Enforce keyword-only arguments (using `*`) in test functions that accept multiple parameters
- This improves call-site clarity and prevents accidental positional argument errors

## Test plan
- [ ] Verify tests still pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only signature changes with no runtime or library behavior impact; primary risk is minor breakage if any tests are invoked positionally outside pytest.
> 
> **Overview**
> Updates the test suite to enforce **keyword-only arguments** for many pytest test functions by inserting `*` in their signatures, improving clarity and preventing accidental positional-argument misuse.
> 
> No production code changes; behavior and assertions remain the same aside from minor signature normalization (e.g., in `test_shell_evaluator` parametrized tests and various parser/evaluator test modules).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf8699984602c14edb1004f7420ca752d5b92b1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->