### PR TITLE
Use * for keyword-only arguments in pytest fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ LANGUAGE_DIRECTIVE_BUILDER_IDS = [
 
 
 @pytest.fixture(name="language", params=ALL_LANGUAGES, ids=LANGUAGE_IDS)
-def fixture_language(request: pytest.FixtureRequest) -> MarkupLanguage:
+def fixture_language(*, request: pytest.FixtureRequest) -> MarkupLanguage:
     """Provide each supported markup language."""
     language = request.param
     if not isinstance(language, MarkupLanguage):  # pragma: no cover
@@ -38,7 +38,9 @@ def fixture_language(request: pytest.FixtureRequest) -> MarkupLanguage:
     params=ALL_LANGUAGES,
     ids=LANGUAGE_IDS,
 )
-def fixture_markup_language(request: pytest.FixtureRequest) -> MarkupLanguage:
+def fixture_markup_language(
+    *, request: pytest.FixtureRequest
+) -> MarkupLanguage:
     """Provide each supported markup language."""
     language: MarkupLanguage = request.param
     return language
@@ -50,6 +52,7 @@ def fixture_markup_language(request: pytest.FixtureRequest) -> MarkupLanguage:
     ids=LANGUAGE_DIRECTIVE_BUILDER_IDS,
 )
 def fixture_language_directive_builder(
+    *,
     request: pytest.FixtureRequest,
 ) -> tuple[MarkupLanguage, DirectiveBuilder]:
     """Provide each (language, directive_builder) combination.

--- a/tests/evaluators/test_multi.py
+++ b/tests/evaluators/test_multi.py
@@ -32,7 +32,7 @@ def _failing_evaluator(example: Example) -> None:
 
 
 @pytest.fixture(name="rst_file")
-def fixture_rst_file(tmp_path: Path) -> Path:
+def fixture_rst_file(*, tmp_path: Path) -> Path:
     """Fixture to create a temporary RST file with Python code blocks."""
     content = """
     .. code-block:: python

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -51,6 +51,7 @@ def make_temp_file_path(*, example: Example) -> Path:
     params=[True, False],
 )
 def fixture_use_pty_option(
+    *,
     request: pytest.FixtureRequest,
 ) -> bool:
     """Test with and without the pseudo-terminal."""
@@ -61,7 +62,7 @@ def fixture_use_pty_option(
 
 
 @pytest.fixture(name="rst_file")
-def fixture_rst_file(tmp_path: Path) -> Path:
+def fixture_rst_file(*, tmp_path: Path) -> Path:
     """Fixture to create a temporary RST file with code blocks."""
     # Relied upon features:
     #


### PR DESCRIPTION
Pytest fixture functions should use `*` for keyword-only arguments when they have arguments. This change adds `*` to all affected fixtures.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signature-only changes in test fixtures; no production code or runtime logic is affected, so risk is minimal.
> 
> **Overview**
> Updates several pytest fixtures to enforce keyword-only parameters by adding `*` to their signatures (e.g., fixtures in `tests/conftest.py`, `tests/evaluators/test_multi.py`, and `tests/evaluators/test_shell_evaluator.py`).
> 
> This is a style/typing consistency change only; fixture behavior and test logic are otherwise unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64a21073b413e24c050c3b92600ee0f8a4e16b74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->