### PR TITLE
Remove create_evaluator function

### DIFF
--- a/src/sybil_extras/evaluators/shell_evaluator.py
+++ b/src/sybil_extras/evaluators/shell_evaluator.py
@@ -285,6 +285,8 @@ class ShellCommandEvaluator:
         use_pty: bool,
         encoding: str | None = None,
         on_modify: _ExampleModified | None = None,
+        source_preparer: SourcePreparer = _NOOP_SOURCE_PREPARER,
+        result_transformer: ResultTransformer = _NOOP_RESULT_TRANSFORMER,
     ) -> None:
         """Initialize the evaluator.
 
@@ -312,6 +314,10 @@ class ShellCommandEvaluator:
                 use the system default.
             on_modify: A callback to run when the example is modified by the
                 evaluator.
+            source_preparer: A callable that extracts source from an example
+                before it is written to the temporary file.
+            result_transformer: A callable that transforms the result before
+                it is written back to the document.
 
         Raises:
             ValueError: If pseudo-terminal is requested on Windows.
@@ -328,6 +334,8 @@ class ShellCommandEvaluator:
             encoding=encoding,
             on_modify=on_modify,
             namespace_key=namespace_key,
+            source_preparer=source_preparer,
+            result_transformer=result_transformer,
         )
         self._evaluator: _ShellCommandRunner | CodeBlockWriterEvaluator
         if write_to_file:

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -24,7 +24,9 @@ from sybil.parsers.markdown import (
 from sybil.parsers.rest.codeblock import CodeBlockParser
 
 from sybil_extras.evaluators.shell_evaluator import (
+    ResultTransformer,
     ShellCommandEvaluator,
+    SourcePreparer,
 )
 from sybil_extras.languages import (
     DJOT,
@@ -1139,3 +1141,103 @@ def test_markdown_code_block_line_number(
     assert "line 4" in captured.err, (
         f"stderr contains 'line 5' instead of 'line 4': {captured.err}"
     )
+
+
+def test_custom_source_preparer(
+    *,
+    rst_file: Path,
+    tmp_path: Path,
+) -> None:
+    """A custom SourcePreparer can transform content before the
+    command.
+    """
+    captured_file = tmp_path / "captured.txt"
+
+    @beartype
+    class UpperSourcePreparer:
+        """Return the example's source in uppercase."""
+
+        def __call__(self, *, example: Example) -> str:
+            """Return source in uppercase."""
+            return str(object=example.parsed).upper()
+
+    assert isinstance(UpperSourcePreparer(), SourcePreparer)
+
+    # $1 is the temp file (args are: sh -c script _ <temp_file>)
+    sh_function = f'cp "$1" "{captured_file.as_posix()}"'
+
+    evaluator = ShellCommandEvaluator(
+        args=["sh", "-c", sh_function, "_"],
+        temp_file_path_maker=make_temp_file_path,
+        pad_file=False,
+        write_to_file=False,
+        use_pty=False,
+        source_preparer=UpperSourcePreparer(),
+    )
+    parser = CodeBlockParser(language="python", evaluator=evaluator)
+    sybil = Sybil(parsers=[parser])
+
+    document = sybil.parse(path=rst_file)
+    (example,) = document.examples()
+    example.evaluate()
+
+    written = captured_file.read_text(encoding="utf-8")
+    expected = "X = 2 + 2\nASSERT X == 4\n"
+    assert written == expected
+
+
+def test_custom_result_transformer(
+    *,
+    tmp_path: Path,
+) -> None:
+    """A custom ResultTransformer can rewrite content before write-
+    back.
+    """
+    content = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           x = 1
+        """
+    )
+    source_file = tmp_path / "source.rst"
+    source_file.write_text(data=content, encoding="utf-8")
+
+    @beartype
+    class SuffixResultTransformer:
+        """Append a comment to the result."""
+
+        def __call__(self, *, content: str, example: Example) -> str:
+            """Append a comment."""
+            del example
+            return content.rstrip("\n") + "  # transformed\n"
+
+    assert isinstance(SuffixResultTransformer(), ResultTransformer)
+
+    evaluator = ShellCommandEvaluator(
+        args=["true"],
+        temp_file_path_maker=make_temp_file_path,
+        pad_file=False,
+        write_to_file=True,
+        use_pty=False,
+        result_transformer=SuffixResultTransformer(),
+    )
+    parser = CodeBlockParser(language="python", evaluator=evaluator)
+    sybil = Sybil(parsers=[parser])
+
+    document = sybil.parse(path=source_file)
+    (example,) = document.examples()
+    example.evaluate()
+
+    expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           x = 1  # transformed
+        """
+    )
+    assert source_file.read_text(encoding="utf-8") == expected


### PR DESCRIPTION
## Summary
- Removes the `create_evaluator` factory function that was no longer needed
- Inlines its logic directly into `ShellCommandEvaluator.__init__` for simplicity
- Eliminates 66 lines of factory code while maintaining identical functionality
- Removes tests that directly exercised the `create_evaluator` function

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that changes construction/API surface (removes `create_evaluator`) but leaves runtime behavior largely the same; main risk is external callers relying on the removed factory.
> 
> **Overview**
> **Removes the `create_evaluator` factory** from `shell_evaluator.py` and drops the now-unused `sybil.typing.Evaluator` import.
> 
> `ShellCommandEvaluator.__init__` now **directly constructs** the internal `_ShellCommandRunner` and conditionally wraps it in `CodeBlockWriterEvaluator` when `write_to_file=True`, while also exposing `source_preparer`/`result_transformer` parameters on `ShellCommandEvaluator`.
> 
> Tests are updated to instantiate `ShellCommandEvaluator` directly and **remove factory-specific test cases**, keeping coverage for custom `SourcePreparer` and `ResultTransformer` via the class API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ee78bc4af21ec75bf8fe04bd1dbeb45928b60e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->