### PR TITLE
Fix README wording

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -528,7 +528,7 @@ comments such as ``{% group: start %}``. This pairs well with
 
 .. code-block:: python
 
-    """Lex djot directives and test them with check_lexer."""
+    """Parse djot directives and test them with check_lexer."""
 
     from sybil.testing import check_lexer
 


### PR DESCRIPTION
## Summary
- Fix docstring wording in code example: "Lex" → "Parse"

## Test plan
- [ ] Visual inspection of the README change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API impact.
> 
> **Overview**
> Updates the README’s Djot directive lexer example docstring to say “Parse” instead of “Lex”, aligning the wording with the lexer’s purpose and the surrounding documentation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77c145d994356c2039c186e2dab610fa8702ff6e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->