### PR TITLE
Refactor RST content variables in test evaluators

### DIFF
--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -53,16 +53,17 @@ def test_writes_modified_content(
         @end
         """
     )
+    rst_content = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+            original
+        """
+    )
     original_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-                original
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_content,
         MARKDOWN: markdown_content,
         MARKDOWN_IT: markdown_content,
         MDX: markdown_content,
@@ -115,16 +116,17 @@ def test_writes_modified_content(
         @end
         """
     )
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+            modified
+        """
+    )
     expected_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-                modified
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MARKDOWN: markdown_expected,
         MARKDOWN_IT: markdown_expected,
         MDX: markdown_expected,
@@ -304,20 +306,21 @@ def test_empty_code_block_write_content(
         After empty code block
         """
     )
+    # There is no code block in reStructuredText that ends with multiple
+    # newlines.
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           foobar
+
+        After empty code block
+        """
+    )
     expected_content = {
-        # There is no code block in reStructuredText that ends with multiple
-        # newlines.
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-               foobar
-
-            After empty code block
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MARKDOWN: markdown_expected,
         MARKDOWN_IT: markdown_expected,
         MDX: markdown_expected,
@@ -412,19 +415,20 @@ def test_empty_code_block_with_options(
         After empty code block
         """
     )
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+           :emphasize-lines: 2,3
+
+           foobar
+
+        After empty code block
+        """
+    )
     expected_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-               :emphasize-lines: 2,3
-
-               foobar
-
-            After empty code block
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MYST: myst_expected,
         MDX: textwrap.dedent(
             text="""\
@@ -736,17 +740,18 @@ def test_indented_existing_block(
             @end
         """
     )
+    rst_original_content = textwrap.dedent(
+        text="""\
+        Not in code block
+
+            .. code-block:: python
+
+               x = 2 + 2
+               assert x == 4
+        """
+    )
     original_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-                .. code-block:: python
-
-                   x = 2 + 2
-                   assert x == 4
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_original_content,
         MARKDOWN: markdown_content,
         MARKDOWN_IT: markdown_content,
         MDX: markdown_content,
@@ -800,16 +805,17 @@ def test_indented_existing_block(
             @end
         """
     )
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+            .. code-block:: python
+
+               foobar
+        """
+    )
     expected_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-                .. code-block:: python
-
-                   foobar
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MARKDOWN: markdown_expected,
         MARKDOWN_IT: markdown_expected,
         MDX: markdown_expected,
@@ -860,16 +866,17 @@ def test_indented_empty_existing_block(
         After code block
         """
     )
+    rst_original_content = textwrap.dedent(
+        text="""\
+        Not in code block
+
+                .. code-block:: python
+
+        After code block
+        """
+    )
     original_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-                    .. code-block:: python
-
-            After code block
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_original_content,
         MARKDOWN: markdown_content,
         MARKDOWN_IT: markdown_content,
         MDX: markdown_content,
@@ -929,18 +936,19 @@ def test_indented_empty_existing_block(
         After code block
         """
     )
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+                .. code-block:: python
+
+                   foobar
+
+        After code block
+        """
+    )
     expected_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-                    .. code-block:: python
-
-                       foobar
-
-            After code block
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MARKDOWN: markdown_expected,
         MARKDOWN_IT: markdown_expected,
         MDX: markdown_expected,

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -426,17 +426,18 @@ def test_write_to_file_new_content_trailing_newlines(
         @end
         """
     )
+    rst_original_content = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           x = 2 + 2
+           assert x == 4
+        """
+    )
     original_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-               x = 2 + 2
-               assert x == 4
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_original_content,
         MARKDOWN: markdown_content,
         MARKDOWN_IT: markdown_content,
         MDX: markdown_content,
@@ -499,18 +500,19 @@ def test_write_to_file_new_content_trailing_newlines(
         @end
         """
     )
+    # There is no code block in reStructuredText that ends with multiple
+    # newlines.
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           foobar
+        """
+    )
     expected_content = {
-        # There is no code block in reStructuredText that ends with multiple
-        # newlines.
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-               foobar
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MARKDOWN: markdown_expected,
         MARKDOWN_IT: markdown_expected,
         MDX: markdown_expected,
@@ -568,17 +570,18 @@ def test_write_to_file_new_content_no_trailing_newlines(
         @end
         """
     )
+    rst_original_content = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           x = 2 + 2
+           assert x == 4
+        """
+    )
     original_content = {
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-               x = 2 + 2
-               assert x == 4
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_original_content,
         MARKDOWN: markdown_content,
         MARKDOWN_IT: markdown_content,
         MDX: markdown_content,
@@ -636,18 +639,19 @@ def test_write_to_file_new_content_no_trailing_newlines(
         @end
         """
     )
+    # There is no code block in reStructuredText that ends with multiple
+    # newlines.
+    rst_expected = textwrap.dedent(
+        text="""\
+        Not in code block
+
+        .. code-block:: python
+
+           foobar
+        """
+    )
     expected_content = {
-        # There is no code block in reStructuredText that ends with multiple
-        # newlines.
-        RESTRUCTUREDTEXT: textwrap.dedent(
-            text="""\
-            Not in code block
-
-            .. code-block:: python
-
-               foobar
-            """
-        ),
+        RESTRUCTUREDTEXT: rst_expected,
         MARKDOWN: markdown_expected,
         MARKDOWN_IT: markdown_expected,
         MDX: markdown_expected,


### PR DESCRIPTION
Extract reStructuredText content strings from inline dictionary definitions into separate variables (rst_content, rst_expected, rst_original_content). This simplifies test dictionaries and prepares for adding DOCUTILS_RST parser variants to test cases in a follow-up PR.

All 154 tests pass. Comments are moved outside the dict for clarity where applicable.

Co-authored-by: Claude Haiku 4.5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only refactor that reorganizes fixture strings and comments without changing evaluator behavior or production code paths.
> 
> **Overview**
> Refactors evaluator tests to **extract reStructuredText fixture/expected strings** (e.g., `rst_content`, `rst_expected`, `rst_original_content`) out of inline dict literals used for `markup_language` selection.
> 
> Also moves RST-specific comments (notably the *no trailing-newline code block* note) outside the dict definitions for readability, with no functional change beyond test code organization.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fc600c064326bd1f65bcdd5e389b1515caaf939. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->