### PR TITLE
Fix incomplete blank body normalization in sphinx_jinja2

### DIFF
--- a/src/sybil_extras/parsers/myst_parser/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/myst_parser/sphinx_jinja2.py
@@ -41,7 +41,7 @@ def _parse_options_and_body(
         body_lines.append(line)
 
     body = "\n".join(body_lines)
-    if body == "\n":
+    if not body.strip():
         body = ""
 
     return options, body

--- a/tests/parsers/myst_parser/test_sphinx_jinja2.py
+++ b/tests/parsers/myst_parser/test_sphinx_jinja2.py
@@ -83,3 +83,30 @@ def test_options_with_blank_body(*, tmp_path: Path) -> None:
     assert example.region.lexemes["options"] == {
         "ctx": '{"name": "World"}',
     }
+
+
+def test_options_with_many_blank_lines_body(*, tmp_path: Path) -> None:
+    """A jinja block with options and multiple blank lines for body."""
+    content = textwrap.dedent(
+        text="""\
+        ```{jinja}
+        :ctx: {"name": "World"}
+
+
+
+        ```
+        """
+    )
+
+    test_document = tmp_path / "test.md"
+    test_document.write_text(data=content, encoding="utf-8")
+
+    parser = SphinxJinja2Parser(evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_document)
+
+    (example,) = document.examples()
+    assert example.parsed == ""
+    assert example.region.lexemes["options"] == {
+        "ctx": '{"name": "World"}',
+    }


### PR DESCRIPTION
Fixes the _parse_options_and_body function in the myst_parser sphinx_jinja2 module to properly normalize whitespace-only bodies for any number of blank lines, not just single newlines. Previously, a jinja block with options followed by 3+ blank lines would retain newlines in the body instead of normalizing to an empty string. Changed the check from 'body == "\n"' to 'not body.strip()' for robustness. Added test_options_with_many_blank_lines_body to verify the fix handles multiple blank lines correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to whitespace normalization in `_parse_options_and_body` plus added regression tests; no security-sensitive logic or broad behavior changes beyond empty-body handling.
> 
> **Overview**
> Fixes `sphinx_jinja2` option/body parsing to treat *any* whitespace-only body (including multiple blank lines) as an empty string by switching the check from `body == "\n"` to `not body.strip()`.
> 
> Adds/updates tests to cover jinja blocks with options and both single and multiple blank-line bodies, asserting the parsed body is `""` and options are preserved.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44f4c3091ac273439978af033dcd13dde1d28e77. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->