### PR TITLE
Fix DOCUTILS_RST empty-argument directive extraction

### DIFF
--- a/src/sybil_extras/parsers/docutils_rst/lexers.py
+++ b/src/sybil_extras/parsers/docutils_rst/lexers.py
@@ -100,7 +100,7 @@ class DirectiveInCommentLexer:
             return None
 
         directive_name = match.group("directive")
-        arguments_text = match.group("arguments")
+        arguments_text = match.group("arguments") or None
 
         # Get the line number (1-indexed in docutils)
         line_num = node.line


### PR DESCRIPTION
## Summary

Fixes #807 — DOCUTILS_RST parser now extracts comment text for empty-argument directives the same way as RESTRUCTUREDTEXT parser, producing consistent error messages for invalid input.

**Change:** Modified DirectiveInCommentLexer to return None (instead of empty string) for the arguments lexeme when a directive has a colon but no text after it. This matches the behavior of sybil library's DirectiveInCommentLexer.

**Tests:** Added test case verifying that `.. custom-skip:` (with colon but no arguments) raises "missing arguments" error consistently across both parsers.

🤖 Generated with Claude Code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small parsing behavior tweak limited to docutils-based RST directive extraction; main risk is minor behavior change for edge-case directives with a trailing colon and no args.
> 
> **Overview**
> Aligns the docutils-based `DirectiveInCommentLexer` with other RST parsing behavior by converting empty matched directive arguments (e.g. `.. custom-skip:`) from `""` to `None`, so downstream validation reports them as *missing* rather than *malformed*.
> 
> Adds a regression test asserting that a colon-without-arguments directive raises `ValueError` with a "missing arguments" message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74396b58ef6910666c9e652748d108675e8b8dc1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->