### PR TITLE
Use match statements in _grouping_utils

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -38,17 +38,18 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
         parsed: object = ex.parsed
         # Skip markers have parsed values like ('next', None)
         match parsed:
-            case ("next", _):
+            case ("next", object()):
                 skip_next = True
-            case ("start", _):
+            case ("start", object()):
                 in_skip_range = True
-            case ("end", _):
+            case ("end", object()):
                 in_skip_range = False
-            case _ if has_source(example=ex):
-                non_skip_count += 1
-                if skip_next or in_skip_range:
-                    skipped_count += 1
-                    skip_next = False
+            case _:
+                if has_source(example=ex):
+                    non_skip_count += 1
+                    if skip_next or in_skip_range:
+                        skipped_count += 1
+                        skip_next = False
 
     return non_skip_count - skipped_count
 

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -37,22 +37,18 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
     for ex in examples_sorted:
         parsed: object = ex.parsed
         # Skip markers have parsed values like ('next', None)
-        if (
-            isinstance(parsed, tuple)
-            and parsed
-            and parsed[0] in {"next", "start", "end"}
-        ):
-            if parsed[0] == "next":
+        match parsed:
+            case ("next", _):
                 skip_next = True
-            elif parsed[0] == "start":
+            case ("start", _):
                 in_skip_range = True
-            else:
+            case ("end", _):
                 in_skip_range = False
-        elif has_source(example=ex):
-            non_skip_count += 1
-            if skip_next or in_skip_range:
-                skipped_count += 1
-                skip_next = False
+            case _ if has_source(example=ex):
+                non_skip_count += 1
+                if skip_next or in_skip_range:
+                    skipped_count += 1
+                    skip_next = False
 
     return non_skip_count - skipped_count
 
@@ -67,9 +63,11 @@ def _get_text(parsed: Lexeme | str) -> str:
     Returns:
         The text content.
     """
-    if isinstance(parsed, Lexeme):
-        return parsed.text
-    return parsed
+    match parsed:
+        case Lexeme():
+            return parsed.text
+        case _:
+            return parsed
 
 
 @beartype
@@ -94,14 +92,15 @@ def _combine_examples_text(
         The combined text.
     """
     first_parsed = examples[0].parsed
-    if isinstance(first_parsed, Lexeme):
-        result_text = first_parsed.text
-        result_offset = first_parsed.offset
-        result_line_offset = first_parsed.line_offset
-    else:
-        result_text = str(object=first_parsed)
-        result_offset = examples[0].region.start
-        result_line_offset = 0
+    match first_parsed:
+        case Lexeme():
+            result_text = first_parsed.text
+            result_offset = first_parsed.offset
+            result_line_offset = first_parsed.line_offset
+        case _:
+            result_text = str(object=first_parsed)
+            result_offset = examples[0].region.start
+            result_line_offset = 0
 
     for example in examples[1:]:
         existing_lines = len(result_text.splitlines())


### PR DESCRIPTION
## Summary
- Replace `if/elif/isinstance` chains with `match/case` in `count_expected_code_blocks`, `_get_text`, and `_combine_examples_text`
- No change to public API

Closes #893

## Test plan
- [x] All 362 grouping-related tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that mainly restructures control flow in `count_expected_code_blocks`, `_get_text`, and `_combine_examples_text` without changing interfaces; potential risk is subtle behavior differences in pattern matching for unexpected `parsed` shapes.
> 
> **Overview**
> Refactors grouping parser helpers in `_grouping_utils.py` to replace `if/elif` + `isinstance` logic with `match/case` pattern matching.
> 
> This updates skip-marker handling in `count_expected_code_blocks` and lexeme/text extraction in `_get_text`/`_combine_examples_text` while keeping the same outputs and public API expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b29d36260cb3f7ff7e43b65f41e0ed96f1add55e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->