### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,23 +2,12 @@
 
 from doctest import ELLIPSIS
 
-import pytest
-from beartype import beartype
 from sybil import Sybil
 from sybil.parsers.rest import (
     ClearNamespaceParser,
     DocTestParser,
     PythonCodeBlockParser,
 )
-
-
-@beartype
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
-
 
 pytest_collect_file = Sybil(
     parsers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
+    "pytest-beartype-tests",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -86,6 +87,9 @@ optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://adamtheturtle.github.io/sybil-extras/"
 urls.Source = "https://github.com/adamtheturtle/sybil-extras"
 
+[dependency-groups]
+dev = []
+
 [tool.setuptools]
 zip-safe = false
 package-data.sybil_extras = [
@@ -99,6 +103,9 @@ packages.find.where = [
 bdist_wheel.universal = true
 
 [tool.setuptools_scm]
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79
@@ -343,7 +350,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` wiring from conftest where it duplicated the plugin.

The dependency is pinned to [git `bc81d99`](https://github.com/adamtheturtle/pytest-beartype-tests/commit/bc81d99) via `[tool.uv.sources]` until a PyPI release includes the Sybil-safe plugin fix.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dev/test configuration, though they may alter how `beartype` is applied during pytest collection and could surface new type errors in tests.
> 
> **Overview**
> Moves `beartype`-wrapping of collected pytest functions out of `conftest.py` and into the external `pytest-beartype-tests` plugin, removing the local `pytest_collection_modifyitems` hook.
> 
> Adds `pytest-beartype-tests` as a dev dependency and pins it via `uv` git source (`rev = "bc81d99"`), plus updates ancillary config (adds `[dependency-groups]` and drops the now-unused Vulture ignore for `pytest_collection_modifyitems`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48d66581ee89e2ae50ee5a8bb9da4b638d2dff32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->