### PR TITLE
Pin pytest-beartype-tests to 2026.4.20 on PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,8 +104,6 @@ bdist_wheel.universal = true
 
 [tool.setuptools_scm]
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ optional-dependencies.dev = [
     "pyright==1.1.408",
     "pyroma==5.0.1",
     "pytest==9.0.3",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "pytest-cov==7.1.0",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
@@ -105,7 +105,6 @@ bdist_wheel.universal = true
 [tool.setuptools_scm]
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79


### PR DESCRIPTION
Replace the temporary `[tool.uv.sources]` git pin to bc81d99 with the published PyPI release `pytest-beartype-tests==2026.4.20` (same Sybil-safe plugin behavior).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-management-only change confined to dev tooling; main risk is CI/dev environment breakage if the PyPI release differs from the previously pinned git commit.
> 
> **Overview**
> Pins `pytest-beartype-tests` in `pyproject.toml` to the published PyPI version `2026.4.20` instead of relying on an unversioned dependency.
> 
> Removes the `[tool.uv].sources.pytest-beartype-tests` git override (previously pinned to a specific commit), simplifying dependency resolution to use standard package installs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c23c1dc0812554c8786f27a2eca7b11c9c1ad939. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->