### PR TITLE
docs: document ThreadSafeSkipParser

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Next
 ----
 
+
+* Added ``ThreadSafeSkipParser`` for each markup language, a thread-safe drop-in replacement for the upstream Sybil skip parser. Skip decisions are resolved at parse time, so concurrent example evaluation produces deterministic results. Each ``MarkupLanguage`` also exposes the parser class as ``thread_safe_skip_parser_cls``.
+
 2026.05.06
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -215,6 +215,49 @@ the Sybil documentation for skipping examples in
 MDX, and `MyST <https://sybil.readthedocs.io/en/latest/myst.html#skipping-examples>`_ files,
 but with custom text, e.g. ``custom-marker-skip`` replacing the word ``skip``.
 
+ThreadSafeSkipParser
+^^^^^^^^^^^^^^^^^^^^
+
+The ``ThreadSafeSkipParser`` is a thread-safe drop-in replacement for the standard skip parser.
+Use it when examples from a single document may be evaluated concurrently (e.g. dispatched across a thread pool).
+
+The upstream ``sybil.evaluators.skip.Skipper`` mutates per-document state as examples are evaluated,
+so concurrent evaluation can race and produce non-deterministic skip decisions
+(see `simplistix/sybil#166 <https://github.com/simplistix/sybil/issues/166>`_).
+``ThreadSafeSkipParser`` resolves each non-skip example to its governing skip directive at parse time,
+and caches conditional ``if`` decisions per directive so concurrent evaluators all see the same result.
+
+.. code-block:: python
+
+    """Use ThreadSafeSkipParser for concurrent example evaluation."""
+
+    from sybil import Sybil
+    from sybil.parsers.rest.codeblock import PythonCodeBlockParser
+
+    # Similar parsers are available at
+    # sybil_extras.parsers.djot.thread_safe_skip,
+    # sybil_extras.parsers.markdown.thread_safe_skip,
+    # sybil_extras.parsers.markdown_it.thread_safe_skip,
+    # sybil_extras.parsers.mdx.thread_safe_skip,
+    # sybil_extras.parsers.myst.thread_safe_skip,
+    # sybil_extras.parsers.myst_parser.thread_safe_skip,
+    # sybil_extras.parsers.norg.thread_safe_skip.
+    from sybil_extras.parsers.rest.thread_safe_skip import (
+        ThreadSafeSkipParser,
+    )
+
+    skip_parser = ThreadSafeSkipParser(directive="skip")
+    code_block_parser = PythonCodeBlockParser()
+
+    sybil = Sybil(parsers=[skip_parser, code_block_parser])
+
+    pytest_collect_file = sybil.pytest()
+
+The directive syntax (``skip: start`` / ``skip: next`` / ``skip: end``,
+including conditional ``skip: next if(...)`` reasons) matches upstream Sybil exactly,
+so existing documents do not need to change.
+The directive name is configurable, so the parser can also be used as a thread-safe replacement for custom skip markers.
+
 GroupedSourceParser
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -215,7 +215,7 @@ ThreadSafeSkipParser
 The ``ThreadSafeSkipParser`` is a thread-safe drop-in replacement for the standard skip parser.
 Use it when examples from a single document may be evaluated concurrently (e.g. dispatched across a thread pool).
 
-The upstream :class:`sybil.evaluators.skip.Skipper` mutates per-document state as examples are evaluated, so concurrent evaluation can race and produce non-deterministic skip decisions (see `simplistix/sybil#166 <https://github.com/simplistix/sybil/issues/166>`_).
+The upstream ``sybil.evaluators.skip.Skipper`` mutates per-document state as examples are evaluated, so concurrent evaluation can race and produce non-deterministic skip decisions (see `simplistix/sybil#166 <https://github.com/simplistix/sybil/issues/166>`_).
 ``ThreadSafeSkipParser`` resolves each non-skip example to its governing skip directive at parse time by walking ``document.regions`` once under a per-document lock.
 Conditional ``if`` reasons are evaluated lazily and cached per directive, so concurrent evaluators all see the same decision.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -209,6 +209,45 @@ the Sybil documentation for skipping examples in
 MDX, and `MyST <https://sybil.readthedocs.io/en/latest/myst.html#skipping-examples>`_ files,
 but with custom text, e.g. ``custom-marker-skip`` replacing the word ``skip``.
 
+ThreadSafeSkipParser
+^^^^^^^^^^^^^^^^^^^^
+
+The ``ThreadSafeSkipParser`` is a thread-safe drop-in replacement for the standard skip parser.
+Use it when examples from a single document may be evaluated concurrently (e.g. dispatched across a thread pool).
+
+The upstream :class:`sybil.evaluators.skip.Skipper` mutates per-document state as examples are evaluated, so concurrent evaluation can race and produce non-deterministic skip decisions (see `simplistix/sybil#166 <https://github.com/simplistix/sybil/issues/166>`_).
+``ThreadSafeSkipParser`` resolves each non-skip example to its governing skip directive at parse time by walking ``document.regions`` once under a per-document lock.
+Conditional ``if`` reasons are evaluated lazily and cached per directive, so concurrent evaluators all see the same decision.
+
+.. code-block:: python
+
+    """Use ThreadSafeSkipParser for concurrent example evaluation."""
+
+    from sybil import Sybil
+    from sybil.parsers.rest.codeblock import PythonCodeBlockParser
+
+    # Similar parsers are available at
+    # sybil_extras.parsers.djot.thread_safe_skip,
+    # sybil_extras.parsers.markdown.thread_safe_skip,
+    # sybil_extras.parsers.markdown_it.thread_safe_skip,
+    # sybil_extras.parsers.mdx.thread_safe_skip,
+    # sybil_extras.parsers.myst.thread_safe_skip,
+    # sybil_extras.parsers.myst_parser.thread_safe_skip,
+    # sybil_extras.parsers.norg.thread_safe_skip.
+    from sybil_extras.parsers.rest.thread_safe_skip import (
+        ThreadSafeSkipParser,
+    )
+
+    skip_parser = ThreadSafeSkipParser(directive="skip")
+    code_block_parser = PythonCodeBlockParser()
+
+    sybil = Sybil(parsers=[skip_parser, code_block_parser])
+
+    pytest_collect_file = sybil.pytest()
+
+The directive syntax (``skip: start`` / ``skip: next`` / ``skip: end``, including conditional ``skip: next if(...)`` reasons) matches upstream Sybil exactly, so existing documents do not need to change.
+Like ``CustomDirectiveSkipParser``, the directive name is configurable, so the parser can also be used as a thread-safe replacement for custom skip markers.
+
 GroupedSourceParser
 ^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary
- Add a `ThreadSafeSkipParser` section to `README.rst` and `docs/source/index.rst`, explaining the upstream `Skipper` race, the parse-time resolution strategy, conditional `if` caching, and listing the per-language import paths.
- Add a `Next` entry to `CHANGELOG.rst` noting the new parser and the `thread_safe_skip_parser_cls` field on `MarkupLanguage`.

## Test plan
- [ ] Sphinx docs build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (README/Sphinx index/changelog) with no runtime behavior modifications; low risk aside from potential doc build formatting issues.
> 
> **Overview**
> Adds documentation for the new `ThreadSafeSkipParser`, explaining the upstream Sybil skip-state race, the parse-time skip-resolution approach, and how to import/use the thread-safe parsers across supported markup languages.
> 
> Updates `CHANGELOG.rst` (Next) to announce `ThreadSafeSkipParser` availability per markup language and note the new `MarkupLanguage.thread_safe_skip_parser_cls` attribute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5219a092499591fac6fe247b9c4f5dde45524cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->