### PR TITLE
Apply beartype to InvalidPyconError

### DIFF
--- a/src/sybil_extras/evaluators/shell_evaluator/exceptions.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/exceptions.py
@@ -1,6 +1,9 @@
 """Exceptions for shell command evaluators."""
 
+from beartype import beartype
 
+
+@beartype
 class InvalidPyconError(ValueError):
     """Raised when pycon content contains lines before the first
     prompt.


### PR DESCRIPTION
## Summary
- Add `@beartype` decorator to `InvalidPyconError` in `shell_evaluator/exceptions.py`, the only code-bearing module in `src/` that lacked it.

## Test plan
- [x] Pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds runtime type-checking decoration to a custom exception class, with no expected behavior change beyond potential decorator overhead.
> 
> **Overview**
> Adds `@beartype` to the `InvalidPyconError` exception in `shell_evaluator/exceptions.py` and imports `beartype`, bringing this module in line with the rest of the `src/` codebase’s beartype usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603dadf69f5afb140ee27fe5240323956f9bf96c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->