### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.dev = [
     "doc8==2.0.0",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.13",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: this only updates a dev-only type-checking dependency version and does not change runtime code paths.
> 
> **Overview**
> Updates the dev optional dependency `mypy[faster-cache]` from `1.20.2` to `2.0.0` in `pyproject.toml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c41d3ecc6950aad9a43cf9ec2cc7dd82fde781f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->