### PR TITLE
Enable mypy parallel workers in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,7 +154,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -166,7 +166,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uvx --python=3.13 doccmd --no-write-to-file --language=python --command="uv
-          run --extra=dev mypy"
+          run --extra=dev mypy --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,7 +154,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy --num-workers=4
+        entry: uv run --extra=dev mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false


### PR DESCRIPTION
## Summary
- add `--num-workers=4` to the `mypy` pre-push hook entry
- update the `mypy-docs` `doccmd --command` string to include `--num-workers=4`

## Test plan
- [x] pre-commit hooks pass during commit
- [ ] run `pre-commit run mypy --all-files`
- [ ] run `pre-commit run mypy-docs --all-files`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts pre-commit hook command lines to use `mypy --num-workers=4`, affecting developer tooling/runtime performance rather than production behavior.
> 
> **Overview**
> Enables parallel type-checking in the pre-push hooks by updating the `mypy` and `mypy-docs` pre-commit entries to run `mypy` with `--num-workers=4` (and switches the main hook from `-m mypy` to invoking `mypy` directly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4459526781606a0a9acfbc940465b704d0c55e50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->