### PR TITLE
Add strict-kwargs pre-commit hook in fix mode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -290,6 +290,16 @@ repos:
         additional_dependencies:
           - *uv_version
 
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: ruff-check-fix
         name: Ruff check fix
         entry: uv run --extra=dev -m ruff check --fix
@@ -327,16 +337,6 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
-
-      - id: strict-kwargs-fix
-        name: strict-kwargs
-        entry: uv run --extra=dev strict-kwargs fix
-        language: python
-        types_or: [python]
-        additional_dependencies:
-          - *uv_version
-        stages: [pre-commit]
-        require_serial: true
 
       - id: doc8
         name: doc8


### PR DESCRIPTION
## Summary
- Add the [strict-kwargs](https://github.com/adamtheturtle/strict-kwargs) pre-commit hook (`rev: 2026.5.18`) with `args: [fix]` so positional call arguments are rewritten to keyword form on commit.
- Skip the hook in pre-commit CI (builds from source and needs a Rust toolchain).
- Mirror `[tool.mypy_strict_kwargs]` into `[tool.strict_kwargs]` where custom ignore lists already exist.

## Test plan
- [ ] `pre-commit run strict-kwargs --all-files`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change; it only affects the order a formatting/refactor hook runs during `pre-commit`.
> 
> **Overview**
> Moves the local `strict-kwargs` auto-fix hook earlier in `.pre-commit-config.yaml`, placing it before the Ruff fix/format hooks so kwargs rewrites happen first.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c10d99addecaebc9603aaf9bb76dfdc89e73ef45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->