### PR TITLE
[codex] Fix pylint-docs after doccmd upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,7 +232,9 @@ MESSAGES-CONTROL.disable = [
 MESSAGES-CONTROL.per-file-ignores = [
     "docs/source/conf.py:invalid-name",
     "docs/source/doccmd_*.py:invalid-name",
+    "docs/source/doccmd_*/*.py:invalid-name",
     "doccmd_README_rst_*.py:invalid-name",
+    "doccmd_*/*.py:invalid-name",
 ]
 # Spelling dictionary name. Available dictionaries: none. To make it working
 # install python-enchant package.

--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -2,6 +2,7 @@ Djot
 Docusaurus
 EOF
 JSX
+Lex
 MDX
 MarkdownIt
 MystParser


### PR DESCRIPTION
After `uv sync --upgrade`, `pylint-docs` failed because upgraded `doccmd` now emits nested `doccmd_*/*.py` paths that were not covered by Pylint's `invalid-name` ignores.

This adds those generated paths for README and docs output and adds `Lex` to the spelling dictionary for the docs lexer example.

Validation: `uv run --extra=dev prek run pylint-docs --all-files --hook-stage manual`, plus commit and push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration-only change: expands `pylint` per-file `invalid-name` ignores for newly generated nested `doccmd` files and updates the spelling whitelist, affecting only docs linting.
> 
> **Overview**
> Fixes `pylint-docs` failures after a `doccmd` upgrade by extending `pylint` `invalid-name` per-file ignores to cover nested generated files (e.g. `docs/source/doccmd_*/*.py` and `doccmd_*/*.py`).
> 
> Adds `Lex` to `spelling_private_dict.txt` to avoid docs spelling false-positives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13f120308e5f73291039e64ff09a903850f83475. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->