### PR TITLE
[codex] Add strict-kwargs fix hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,7 @@ ci:
     - shfmt
     - shfmt-docs
     - sphinx-lint
+    - strict-kwargs-fix
     - vulture
     - vulture-docs
     - yamlfix
@@ -326,6 +327,16 @@ repos:
         additional_dependencies:
           - *uv_version
         stages: [pre-commit]
+
+      - id: strict-kwargs-fix
+        name: strict-kwargs
+        entry: uv run --extra=dev strict-kwargs fix
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
 
       - id: doc8
         name: doc8

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18.post1",
+    "strict-kwargs==2026.5.18.post3",
     "sybil==10.0.1",
     "ty==0.0.36",
     "uv==0.11.14",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    "strict-kwargs==2026.5.18.post1",
     "sybil==10.0.1",
     "ty==0.0.36",
     "uv==0.11.14",
@@ -330,6 +331,18 @@ report.show_missing = true
 # pins the signature to the minimum-supported version. Opt the
 # call out so we can pass arguments positionally everywhere.
 ignore_names = [ "builtins.eval" ]
+
+[tool.strict_kwargs]
+ignore_names = [
+    # ``builtins.eval`` has a version-gated typeshed signature: on
+    # 3.13+ ``globals`` and ``locals`` are positional-or-keyword,
+    # but at the project's minimum Python (3.11) they are
+    # positional-only at runtime.
+    "builtins.eval",
+    # ``LexerCollection`` inherits ``list.__init__``, whose first
+    # argument is positional-only at runtime.
+    "sybil.parsers.abstract.lexers.LexerCollection.__call__",
+]
 
 [tool.pydocstringformatter]
 write = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
-    "strict-kwargs==2026.5.18.post3",
+    "strict-kwargs==2026.5.18.post4",
     "sybil==10.0.1",
     "ty==0.0.36",
     "uv==0.11.14",
@@ -339,9 +339,6 @@ ignore_names = [
     # but at the project's minimum Python (3.11) they are
     # positional-only at runtime.
     "builtins.eval",
-    # ``LexerCollection`` inherits ``list.__init__``, whose first
-    # argument is positional-only at runtime.
-    "sybil.parsers.abstract.lexers.LexerCollection.__call__",
 ]
 
 [tool.pydocstringformatter]


### PR DESCRIPTION
Adds the standalone strict-kwargs fixer as a local pre-commit hook and dev dependency. Pins strict-kwargs to 2026.5.18.post4, which no longer rewrites Sybil's LexerCollection constructor incorrectly. Configures strict-kwargs to keep builtins.eval positional for minimum-version runtime compatibility. Validated with strict-kwargs fix, focused ty checks, focused parser tests, and the commit/push hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes developer tooling (new dev dependency and pre-commit hook) and does not affect runtime behavior, aside from potential formatting/churn when contributors run the fixer.
> 
> **Overview**
> **Adds automated keyword-argument normalization via `strict-kwargs` to the dev workflow.** The PR introduces a new local pre-commit hook `strict-kwargs-fix` (run serially) and adds `strict-kwargs` to `optional-dependencies.dev`.
> 
> It also adds `[tool.strict_kwargs]` configuration to ignore `builtins.eval` so the fixer won’t rewrite calls in a way that breaks minimum-supported Python runtimes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02eeb54fa5032bef64a4181202e991cdc2418505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->