### PR TITLE
[codex] Remove Click capture workaround

### DIFF
--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -8,26 +8,22 @@ import contextlib
 import os
 import subprocess
 import sys
-import threading
 from collections.abc import Mapping
-from io import BytesIO
 from pathlib import Path
-from typing import IO
 
 from beartype import beartype
 
 
 @beartype
-def _process_stream(
+def _forward_stream_to_fd(
     *,
     stream_fileno: int,
-    output: IO[bytes] | BytesIO,
+    output_fileno: int,
 ) -> None:
-    """Write from an input stream to an output stream."""
+    """Write from an input stream to an output file descriptor."""
     chunk_size = 1024
     while chunk := os.read(stream_fileno, chunk_size):
-        output.write(chunk)
-        output.flush()
+        os.write(output_fileno, chunk)
 
 
 @beartype
@@ -82,64 +78,21 @@ def run_command(
             # I think that this may be described in
             # https://bugs.python.org/issue5380#msg82827
             with contextlib.suppress(OSError):
-                _process_stream(
+                _forward_stream_to_fd(
                     stream_fileno=stdout_master_fd,
-                    output=sys.stdout.buffer,
+                    output_fileno=1,
                 )
 
             os.close(fd=stdout_master_fd)
+            return_code = process.wait()
 
     else:
-        # We use ``subprocess.PIPE`` + threads rather than passing
-        # ``stdout=sys.stdout.buffer`` directly to ``Popen``.
-        #
-        # ``Popen`` accepts a file-like object for ``stdout``/``stderr``
-        # only if it exposes a real OS file descriptor via ``fileno()``.
-        # When test frameworks such as pytest replace ``sys.stdout`` with
-        # a ``StringIO``-based capture object, ``sys.stdout.buffer.fileno()``
-        # raises ``io.UnsupportedOperation``.
-        #
-        # By routing data through ``subprocess.PIPE`` we always get genuine
-        # OS-level pipe file descriptors.  The background threads then read
-        # from those descriptors and write into ``sys.stdout.buffer`` /
-        # ``sys.stderr.buffer``, which may be the real terminal or a
-        # test-framework capture object — either way the write is safe.
-        # This preserves live streaming: output is forwarded chunk-by-chunk
-        # rather than being buffered until the process exits.
         with subprocess.Popen(
             args=command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
             env=env,
         ) as process:
-            if (
-                process.stdout is None or process.stderr is None
-            ):  # pragma: no cover
-                raise ValueError
-
-            stdout_thread = threading.Thread(
-                target=_process_stream,
-                kwargs={
-                    "stream_fileno": process.stdout.fileno(),
-                    "output": sys.stdout.buffer,
-                },
-            )
-            stderr_thread = threading.Thread(
-                target=_process_stream,
-                kwargs={
-                    "stream_fileno": process.stderr.fileno(),
-                    "output": sys.stderr.buffer,
-                },
-            )
-
-            stdout_thread.start()
-            stderr_thread.start()
-
-            stdout_thread.join()
-            stderr_thread.join()
-
-    return_code = process.wait()
+            return_code = process.wait()
 
     return subprocess.CompletedProcess(
         args=command,

--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 from beartype import beartype
 
+STDOUT_FILENO = 1
+
 
 @beartype
 def _forward_stream_to_fd(
@@ -78,9 +80,11 @@ def run_command(
             # I think that this may be described in
             # https://bugs.python.org/issue5380#msg82827
             with contextlib.suppress(OSError):
+                # Click's fd capture redirects file descriptor 1, while
+                # ``sys.stdout.fileno()`` points at the saved original fd.
                 _forward_stream_to_fd(
                     stream_fileno=stdout_master_fd,
-                    output_fileno=1,
+                    output_fileno=STDOUT_FILENO,
                 )
 
             os.close(fd=stdout_master_fd)

--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -80,8 +80,8 @@ def run_command(
             # I think that this may be described in
             # https://bugs.python.org/issue5380#msg82827
             with contextlib.suppress(OSError):
-                # Click's fd capture redirects file descriptor 1, while
-                # ``sys.stdout.fileno()`` points at the saved original fd.
+                # Click capture redirects file descriptor 1, while
+                # ``sys.stdout.fileno()`` points at the saved original.
                 _forward_stream_to_fd(
                     stream_fileno=stdout_master_fd,
                     output_fileno=STDOUT_FILENO,

--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -22,7 +22,7 @@ def _forward_stream_to_fd(
 ) -> None:
     """Write from an input stream to an output file descriptor."""
     chunk_size = 1024
-    while chunk := os.read(stream_fileno, chunk_size):
+    while chunk := os.read(stream_fileno, chunk_size):  # pragma: no branch
         os.write(output_fileno, chunk)
 
 

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -124,7 +124,7 @@ def test_error(*, rst_file: Path, use_pty_option: bool) -> None:
 def test_output_shown(
     *,
     rst_file: Path,
-    capsys: pytest.CaptureFixture[str],
+    capfd: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """Output is shown."""
@@ -145,7 +145,7 @@ def test_output_shown(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    outerr = capsys.readouterr()
+    outerr = capfd.readouterr()
     expected_output = "Hello, Sybil!\n"
     expected_stderr = "Hello Stderr!\n"
     if use_pty_option:
@@ -159,7 +159,7 @@ def test_output_shown(
 def test_rm(
     *,
     rst_file: Path,
-    capsys: pytest.CaptureFixture[str],
+    capfd: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """Output is shown."""
@@ -176,7 +176,7 @@ def test_rm(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    outerr = capsys.readouterr()
+    outerr = capfd.readouterr()
     assert outerr.out == ""
     assert outerr.err == ""
 
@@ -278,7 +278,7 @@ def test_file_is_passed(
 def test_file_path(
     *,
     rst_file: Path,
-    capsys: pytest.CaptureFixture[str],
+    capfd: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """
@@ -298,7 +298,7 @@ def test_file_path(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    output = capsys.readouterr().out
+    output = capfd.readouterr().out
     stripped_output = output.strip()
     assert stripped_output
     given_file_path = Path(stripped_output)
@@ -307,7 +307,7 @@ def test_file_path(
     assert not given_file_path.exists()
     assert given_file_path.name.startswith("temp_")
     example.evaluate()
-    output = capsys.readouterr().out
+    output = capfd.readouterr().out
     new_given_file_path = Path(output.strip())
     assert new_given_file_path != given_file_path
 
@@ -315,7 +315,7 @@ def test_file_path(
 def test_temp_file_path_maker(
     *,
     rst_file: Path,
-    capsys: pytest.CaptureFixture[str],
+    capfd: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """A custom filename generator is used when provided."""
@@ -338,7 +338,7 @@ def test_temp_file_path_maker(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    output = capsys.readouterr().out
+    output = capfd.readouterr().out
     stripped_output = output.strip()
     assert stripped_output
     given_file_path = Path(stripped_output)
@@ -697,7 +697,7 @@ def test_pad_and_write(*, rst_file: Path, use_pty_option: bool) -> None:
 def test_non_utf8_output(
     *,
     rst_file: Path,
-    capsysbinary: pytest.CaptureFixture[bytes],
+    capfdbinary: pytest.CaptureFixture[bytes],
     tmp_path: Path,
     use_pty_option: bool,
 ) -> None:
@@ -721,7 +721,7 @@ def test_non_utf8_output(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    output = capsysbinary.readouterr().out
+    output = capfdbinary.readouterr().out
     expected_output = b"\xc0\x80\n"
     if use_pty_option:
         expected_output = expected_output.replace(b"\n", b"\r\n")
@@ -942,7 +942,7 @@ def test_click_runner(*, rst_file: Path, use_pty_option: bool) -> None:
         (example,) = document.examples()
         example.evaluate()
 
-    runner = CliRunner()
+    runner = CliRunner(capture="fd")
     result = runner.invoke(cli=_main)
     assert result.exit_code == 0, (result.stdout, result.stderr)
     expected_output = "Hello, Sybil!\n"
@@ -1092,7 +1092,7 @@ def test_custom_on_modify_with_modification(
 def test_markdown_code_block_line_number(
     *,
     tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
+    capfd: pytest.CaptureFixture[str],
     parser_cls: type,
 ) -> None:
     """Line numbers in error output match the source file for Markdown.
@@ -1146,7 +1146,7 @@ def test_markdown_code_block_line_number(
     with pytest.raises(expected_exception=subprocess.CalledProcessError):
         example.evaluate()
 
-    captured = capsys.readouterr()
+    captured = capfd.readouterr()
     # The error should report line 4, not line 5.
     # The syntax error is on line 4 of the original file.
     assert "line 4" in captured.err, (

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -920,6 +920,8 @@ def test_bad_command_error(*, rst_file: Path, use_pty_option: bool) -> None:
 
 def test_click_runner(*, rst_file: Path, use_pty_option: bool) -> None:
     """The click runner can pick up the command output."""
+    if sys.platform == "win32":  # pragma: no cover
+        pytest.skip(reason='Click does not support capture="fd" on Windows.')
 
     @click.command()
     def _main() -> None:


### PR DESCRIPTION
Removes the subprocess pipe/thread forwarding workaround now that Click 8.4 can capture file descriptors via CliRunner(capture="fd"). Non-PTY commands inherit stdout/stderr directly, while PTY output is forwarded to fd 1 with os.write. Tests now use fd-level pytest capture and exercise Click's fd capture mode. Validated with the full pytest suite plus Ruff, mypy, pyright, and push-time hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how shell-command output is streamed/captured by switching non-PTY execution to inherit stdout/stderr directly and PTY forwarding to raw fd 1, which can affect output visibility in different runners (pytest/click) and on Windows.
> 
> **Overview**
> Simplifies `run_command` output streaming by removing the `subprocess.PIPE` + background-thread forwarding workaround for non-PTY runs; commands now inherit the parent stdout/stderr directly.
> 
> For PTY mode, replaces writing to `sys.stdout.buffer` with forwarding bytes to a fixed `STDOUT_FILENO` via `os.write`, so Click’s fd-level capture can intercept output.
> 
> Updates tests to use pytest’s `capfd`/`capfdbinary` instead of `capsys` and adjusts the Click integration test to run `CliRunner(capture="fd")` (skipping on Windows where Click lacks fd capture).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e11dde278e0361ac33d8ade9c96823b679fea8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->