### PR TITLE
Ban dynamic builtins and typing.cast in lint config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,7 @@ lint.per-file-ignores."tests/**/test_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 
 [tool.pylint]
@@ -181,6 +182,17 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+DEPRECATED_BUILTINS.bad-functions = [
+    # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
+    # make this removable:
+    # https://github.com/astral-sh/ruff/issues/10079
+    # https://github.com/astral-sh/ruff/issues/970
+    "filter",
+    "getattr",
+    "hasattr",
+    "map",
+    "setattr",
+]
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where

--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -54,9 +54,13 @@ def run_command(
     if use_pty:
         stdout_master_fd: int = -1
         slave_fd: int = -1
-        # ``os.openpty`` is unavailable on Windows; ``sys.platform`` narrows
-        # for type checkers on non-Windows platforms.
-        if sys.platform != "win32":  # pragma: no branch
+        # We use ``hasattr`` rather than
+        # ``contextlib.suppress(AttributeError)`` so that ``mypy`` can narrow
+        # the type on Windows, where ``os.openpty`` does not exist.
+        # We also check ``sys.platform`` so that pyright can narrow the type.
+        if sys.platform != "win32" and hasattr(  # pylint: disable=bad-builtin
+            os, "openpty"
+        ):  # pragma: no branch
             stdout_master_fd, slave_fd = os.openpty()
 
         stdout: int = slave_fd

--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -54,13 +54,9 @@ def run_command(
     if use_pty:
         stdout_master_fd: int = -1
         slave_fd: int = -1
-        # We use ``hasattr`` rather than
-        # ``contextlib.suppress(AttributeError)`` so that ``mypy`` can narrow
-        # the type on Windows, where ``os.openpty`` does not exist.
-        # We also check ``sys.platform`` so that pyright can narrow the type.
-        if sys.platform != "win32" and hasattr(
-            os, "openpty"
-        ):  # pragma: no branch
+        # ``os.openpty`` is unavailable on Windows; ``sys.platform`` narrows
+        # for type checkers on non-Windows platforms.
+        if sys.platform != "win32":  # pragma: no branch
             stdout_master_fd, slave_fd = os.openpty()
 
         stdout: int = slave_fd

--- a/tests/parsers/test_thread_safe_skip.py
+++ b/tests/parsers/test_thread_safe_skip.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast  # noqa: TID251
 from unittest import SkipTest
 
 import pytest
@@ -70,8 +70,9 @@ def _build_sybil(
     """Build a Sybil instance with the thread-safe skip parser
     configured.
     """
-    skip_parser = language.thread_safe_skip_parser_cls(
-        directive=directive_name,
+    skip_parser = cast(  # noqa: TID251
+        "_ThreadSafeSkipParserProtocol",
+        language.thread_safe_skip_parser_cls(directive=directive_name),
     )
     code_block_parser = language.code_block_parser_cls(
         language="python",

--- a/tests/parsers/test_thread_safe_skip.py
+++ b/tests/parsers/test_thread_safe_skip.py
@@ -70,7 +70,7 @@ def _build_sybil(
     """Build a Sybil instance with the thread-safe skip parser
     configured.
     """
-    skip_parser = cast(  # noqa: TID251
+    skip_parser = cast(
         "_ThreadSafeSkipParserProtocol",
         language.thread_safe_skip_parser_cls(directive=directive_name),
     )

--- a/tests/parsers/test_thread_safe_skip.py
+++ b/tests/parsers/test_thread_safe_skip.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Protocol
 from unittest import SkipTest
 
 import pytest
@@ -70,9 +70,8 @@ def _build_sybil(
     """Build a Sybil instance with the thread-safe skip parser
     configured.
     """
-    skip_parser = cast(
-        "_ThreadSafeSkipParserProtocol",
-        language.thread_safe_skip_parser_cls(directive=directive_name),
+    skip_parser: _ThreadSafeSkipParserProtocol = (
+        language.thread_safe_skip_parser_cls(directive=directive_name)
     )
     code_block_parser = language.code_block_parser_cls(
         language="python",

--- a/tests/parsers/test_thread_safe_skip.py
+++ b/tests/parsers/test_thread_safe_skip.py
@@ -70,8 +70,8 @@ def _build_sybil(
     """Build a Sybil instance with the thread-safe skip parser
     configured.
     """
-    skip_parser: _ThreadSafeSkipParserProtocol = (
-        language.thread_safe_skip_parser_cls(directive=directive_name)
+    skip_parser = language.thread_safe_skip_parser_cls(
+        directive=directive_name,
     )
     code_block_parser = language.code_block_parser_cls(
         language="python",


### PR DESCRIPTION
## Summary
- Add literalizer DEPRECATED_BUILTINS.bad-functions pylint config.
- Ban typing.cast via ruff where applicable.
- Fix or pylint-disable existing violations.

## Test plan
- [ ] CI lint passes.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily lint configuration changes with minor inline suppressions; runtime logic is unchanged aside from linter directives.
> 
> **Overview**
> Tightens linting rules by **banning `typing.cast` via Ruff** (custom `banned-api` message) and by **flagging dynamic builtin calls** (`filter`, `map`, `getattr`, `setattr`, `hasattr`) via Pylint `DEPRECATED_BUILTINS.bad-functions`.
> 
> Adds targeted suppressions where existing code intentionally relies on these: `# noqa: TID251` for `cast` usage in tests, and a `pylint: disable=bad-builtin` on the `hasattr(os, "openpty")` guard in `_subprocess_utils.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67e3c8b32ff5755e9fb633ed2a41c9a7ba830997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->