### PR TITLE
Revert "[codex] Remove Click capture workaround"

### DIFF
--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -8,24 +8,26 @@ import contextlib
 import os
 import subprocess
 import sys
+import threading
 from collections.abc import Mapping
+from io import BytesIO
 from pathlib import Path
+from typing import IO
 
 from beartype import beartype
 
-STDOUT_FILENO = 1
-
 
 @beartype
-def _forward_stream_to_fd(
+def _process_stream(
     *,
     stream_fileno: int,
-    output_fileno: int,
+    output: IO[bytes] | BytesIO,
 ) -> None:
-    """Write from an input stream to an output file descriptor."""
+    """Write from an input stream to an output stream."""
     chunk_size = 1024
-    while chunk := os.read(stream_fileno, chunk_size):  # pragma: no branch
-        os.write(output_fileno, chunk)
+    while chunk := os.read(stream_fileno, chunk_size):
+        output.write(chunk)
+        output.flush()
 
 
 @beartype
@@ -80,23 +82,64 @@ def run_command(
             # I think that this may be described in
             # https://bugs.python.org/issue5380#msg82827
             with contextlib.suppress(OSError):
-                # Click capture redirects file descriptor 1, while
-                # ``sys.stdout.fileno()`` points at the saved original.
-                _forward_stream_to_fd(
+                _process_stream(
                     stream_fileno=stdout_master_fd,
-                    output_fileno=STDOUT_FILENO,
+                    output=sys.stdout.buffer,
                 )
 
             os.close(fd=stdout_master_fd)
-            return_code = process.wait()
 
     else:
+        # We use ``subprocess.PIPE`` + threads rather than passing
+        # ``stdout=sys.stdout.buffer`` directly to ``Popen``.
+        #
+        # ``Popen`` accepts a file-like object for ``stdout``/``stderr``
+        # only if it exposes a real OS file descriptor via ``fileno()``.
+        # When test frameworks such as pytest replace ``sys.stdout`` with
+        # a ``StringIO``-based capture object, ``sys.stdout.buffer.fileno()``
+        # raises ``io.UnsupportedOperation``.
+        #
+        # By routing data through ``subprocess.PIPE`` we always get genuine
+        # OS-level pipe file descriptors.  The background threads then read
+        # from those descriptors and write into ``sys.stdout.buffer`` /
+        # ``sys.stderr.buffer``, which may be the real terminal or a
+        # test-framework capture object — either way the write is safe.
+        # This preserves live streaming: output is forwarded chunk-by-chunk
+        # rather than being buffered until the process exits.
         with subprocess.Popen(
             args=command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             stdin=subprocess.PIPE,
             env=env,
         ) as process:
-            return_code = process.wait()
+            if (
+                process.stdout is None or process.stderr is None
+            ):  # pragma: no cover
+                raise ValueError
+
+            stdout_thread = threading.Thread(
+                target=_process_stream,
+                kwargs={
+                    "stream_fileno": process.stdout.fileno(),
+                    "output": sys.stdout.buffer,
+                },
+            )
+            stderr_thread = threading.Thread(
+                target=_process_stream,
+                kwargs={
+                    "stream_fileno": process.stderr.fileno(),
+                    "output": sys.stderr.buffer,
+                },
+            )
+
+            stdout_thread.start()
+            stderr_thread.start()
+
+            stdout_thread.join()
+            stderr_thread.join()
+
+    return_code = process.wait()
 
     return subprocess.CompletedProcess(
         args=command,

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -124,7 +124,7 @@ def test_error(*, rst_file: Path, use_pty_option: bool) -> None:
 def test_output_shown(
     *,
     rst_file: Path,
-    capfd: pytest.CaptureFixture[str],
+    capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """Output is shown."""
@@ -145,7 +145,7 @@ def test_output_shown(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    outerr = capfd.readouterr()
+    outerr = capsys.readouterr()
     expected_output = "Hello, Sybil!\n"
     expected_stderr = "Hello Stderr!\n"
     if use_pty_option:
@@ -159,7 +159,7 @@ def test_output_shown(
 def test_rm(
     *,
     rst_file: Path,
-    capfd: pytest.CaptureFixture[str],
+    capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """Output is shown."""
@@ -176,7 +176,7 @@ def test_rm(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    outerr = capfd.readouterr()
+    outerr = capsys.readouterr()
     assert outerr.out == ""
     assert outerr.err == ""
 
@@ -278,7 +278,7 @@ def test_file_is_passed(
 def test_file_path(
     *,
     rst_file: Path,
-    capfd: pytest.CaptureFixture[str],
+    capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """
@@ -298,7 +298,7 @@ def test_file_path(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    output = capfd.readouterr().out
+    output = capsys.readouterr().out
     stripped_output = output.strip()
     assert stripped_output
     given_file_path = Path(stripped_output)
@@ -307,7 +307,7 @@ def test_file_path(
     assert not given_file_path.exists()
     assert given_file_path.name.startswith("temp_")
     example.evaluate()
-    output = capfd.readouterr().out
+    output = capsys.readouterr().out
     new_given_file_path = Path(output.strip())
     assert new_given_file_path != given_file_path
 
@@ -315,7 +315,7 @@ def test_file_path(
 def test_temp_file_path_maker(
     *,
     rst_file: Path,
-    capfd: pytest.CaptureFixture[str],
+    capsys: pytest.CaptureFixture[str],
     use_pty_option: bool,
 ) -> None:
     """A custom filename generator is used when provided."""
@@ -338,7 +338,7 @@ def test_temp_file_path_maker(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    output = capfd.readouterr().out
+    output = capsys.readouterr().out
     stripped_output = output.strip()
     assert stripped_output
     given_file_path = Path(stripped_output)
@@ -697,7 +697,7 @@ def test_pad_and_write(*, rst_file: Path, use_pty_option: bool) -> None:
 def test_non_utf8_output(
     *,
     rst_file: Path,
-    capfdbinary: pytest.CaptureFixture[bytes],
+    capsysbinary: pytest.CaptureFixture[bytes],
     tmp_path: Path,
     use_pty_option: bool,
 ) -> None:
@@ -721,7 +721,7 @@ def test_non_utf8_output(
     document = sybil.parse(path=rst_file)
     (example,) = document.examples()
     example.evaluate()
-    output = capfdbinary.readouterr().out
+    output = capsysbinary.readouterr().out
     expected_output = b"\xc0\x80\n"
     if use_pty_option:
         expected_output = expected_output.replace(b"\n", b"\r\n")
@@ -920,8 +920,6 @@ def test_bad_command_error(*, rst_file: Path, use_pty_option: bool) -> None:
 
 def test_click_runner(*, rst_file: Path, use_pty_option: bool) -> None:
     """The click runner can pick up the command output."""
-    if sys.platform == "win32":  # pragma: no cover
-        pytest.skip(reason='Click does not support capture="fd" on Windows.')
 
     @click.command()
     def _main() -> None:
@@ -944,7 +942,7 @@ def test_click_runner(*, rst_file: Path, use_pty_option: bool) -> None:
         (example,) = document.examples()
         example.evaluate()
 
-    runner = CliRunner(capture="fd")
+    runner = CliRunner()
     result = runner.invoke(cli=_main)
     assert result.exit_code == 0, (result.stdout, result.stderr)
     expected_output = "Hello, Sybil!\n"
@@ -1094,7 +1092,7 @@ def test_custom_on_modify_with_modification(
 def test_markdown_code_block_line_number(
     *,
     tmp_path: Path,
-    capfd: pytest.CaptureFixture[str],
+    capsys: pytest.CaptureFixture[str],
     parser_cls: type,
 ) -> None:
     """Line numbers in error output match the source file for Markdown.
@@ -1148,7 +1146,7 @@ def test_markdown_code_block_line_number(
     with pytest.raises(expected_exception=subprocess.CalledProcessError):
         example.evaluate()
 
-    captured = capfd.readouterr()
+    captured = capsys.readouterr()
     # The error should report line 4, not line 5.
     # The syntax error is on line 4 of the original file.
     assert "line 4" in captured.err, (


### PR DESCRIPTION
Reverts adamtheturtle/sybil-extras#957

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess execution and output streaming, switching to threaded pipe forwarding; this can change ordering/interleaving of stdout/stderr and introduce platform-specific edge cases.
> 
> **Overview**
> Improves `run_command` output handling to work when `sys.stdout`/`sys.stderr` are replaced by test/framework capture objects: non-PTY execution now uses `stdout/stderr=PIPE` and background threads to stream pipe bytes into `sys.stdout.buffer`/`sys.stderr.buffer` without requiring a real `fileno()`.
> 
> Refactors the stream forwarder to write to an output stream (instead of an output FD), and updates shell evaluator tests to capture via `capsys`/`capsysbinary` and to use `CliRunner()` (dropping the `capture="fd"` workaround and related Windows skip).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f24fd3541aeddb2b1f21b89ec288de800ba651a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->