### PR TITLE
[codex] Drive changelog releases from towncrier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,41 +47,27 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get the changelog underline
-        id: changelog_underline
+      # towncrier writes the rendered notes to stdout (informational
+      # chatter goes to stderr), so this is the curated release body for
+      # this version, not github-tag-action's commit-derived changelog.
+      - name: Generate the GitHub release notes
         env:
           RELEASE: ${{ steps.calver.outputs.release }}
-        run: |
-          underline="$(echo "$RELEASE" | tr -c '\n' '-')"
-          echo "underline=${underline}" >> "$GITHUB_OUTPUT"
+        run: uv run --extra=release towncrier build --draft --version "$RELEASE" >
+          release-notes.md
 
-      - name: Update changelog
-        id: update_changelog
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: "Next\n----"
-          replace: |
-            Next
-            ----
-
-            ${{ steps.calver.outputs.release }}
-            ${{ steps.changelog_underline.outputs.underline }}
-          include: CHANGELOG.rst
-          regex: false
-
-      - name: Check Update changelog was modified
+      # Assemble the same fragments into CHANGELOG.rst under a new
+      # ``$RELEASE`` section and delete the consumed fragment files.
+      - name: Update the changelog
         env:
-          MODIFIED_FILES: ${{ steps.update_changelog.outputs.modifiedFiles }}
-        run: |
-          if [ "$MODIFIED_FILES" = "0" ]; then
-            echo "Error: No files were modified when updating changelog"
-            exit 1
-          fi
+          RELEASE: ${{ steps.calver.outputs.release }}
+        run: uv run --extra=release towncrier build --yes --version "$RELEASE"
+
       - uses: stefanzweifel/git-auto-commit-action@v7
         id: commit
         with:
           commit_message: Bump CHANGELOG
-          file_pattern: CHANGELOG.rst
+          file_pattern: CHANGELOG.rst newsfragments
           # Error if there are no changes.
           skip_dirty_check: true
 
@@ -100,7 +86,7 @@ jobs:
           tag: ${{ steps.tag_version.outputs.new_tag }}
           makeLatest: true
           name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
+          bodyFile: release-notes.md
 
       - name: Build a binary wheel and a source tarball
         env:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,7 @@
 Changelog
 =========
 
-Next
-----
+.. towncrier release notes start
 
 2026.05.20
 ----------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,8 +22,17 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "sphinxcontrib.spelling",
+    "sphinxcontrib.towncrier.ext",
     "sphinx_substitution_extensions",
 ]
+
+# Render the unreleased ``newsfragments/`` entries into
+# ``docs/source/unreleased.rst`` so the Sphinx spelling, doc-build and
+# link-checking gates cover the prose before it is assembled into
+# CHANGELOG.rst at release time.
+towncrier_draft_autoversion_mode = "draft"
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = f"{_pyproject_file.parent}"
 
 templates_path = ["_templates"]
 source_suffix = ".rst"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -703,4 +703,5 @@ Reference
    install
    contributing
    release-process
+   unreleased
    changelog

--- a/docs/source/unreleased.rst
+++ b/docs/source/unreleased.rst
@@ -1,0 +1,8 @@
+Unreleased changes
+==================
+
+Changes that have landed on the main branch but are not yet part of a
+tagged release.  These entries are assembled into the
+:doc:`changelog` when the next release is published.
+
+.. towncrier-draft-entries::

--- a/docs/towncrier_template.rst.jinja
+++ b/docs/towncrier_template.rst.jinja
@@ -1,0 +1,14 @@
+
+{% for section_name, section in sections.items() %}
+{% if section %}
+{% for category, entries in section.items() %}
+{% for text, _ in entries.items() %}
+- {{ text }}
+
+{% endfor %}
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}
+{% endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,12 @@ optional-dependencies.dev = [
     "sphinx-pyproject==0.3.0",
     "sphinx-substitution-extensions==2026.1.12",
     "sphinxcontrib-spelling==8.0.2",
+    # ``sphinxcontrib-towncrier`` renders unreleased news fragments
+    # into docs/source/unreleased.rst during Sphinx builds.
+    "sphinxcontrib-towncrier==0.5.0a0",
     "strict-kwargs==2026.5.19.post3",
     "sybil==10.0.1",
+    "towncrier==25.8.0",
     "ty==0.0.37",
     "uv==0.11.15",
     "vulture==2.16",
@@ -269,6 +273,8 @@ ignore = [
     ".shellcheckrc",
     ".vscode/**",
     "CHANGELOG.rst",
+    "newsfragments",
+    "newsfragments/**",
     "CODE_OF_CONDUCT.rst",
     "CONTRIBUTING.rst",
     "LICENSE",
@@ -333,6 +339,30 @@ report.exclude_also = [
     "if TYPE_CHECKING:",
 ]
 report.show_missing = true
+
+[tool.towncrier]
+# The changelog and the per-release GitHub release notes are both built
+# from news fragments under ``newsfragments/``.  The release workflow
+# runs ``towncrier build`` to assemble them; contributors add one
+# fragment file per user-facing change.
+directory = "newsfragments"
+filename = "CHANGELOG.rst"
+# Custom template so an assembled version reproduces the historical
+# style exactly: a bare ``<version>`` heading (no project name, no
+# date) followed by a flat bullet list with no per-type sub-headings.
+template = "docs/towncrier_template.rst.jinja"
+title_format = "{version}"
+# ``title_format`` underline first, then any nested headings.  A bare
+# version such as ``2026.05.18`` underlined with ``-`` matches every
+# pre-towncrier entry in CHANGELOG.rst.
+underlines = [ "-", "~", "^" ]
+issue_format = "#{issue}"
+type = [
+    # A single, unnamed fragment type keeps the assembled output as one
+    # flat bullet list, matching the historical changelog (which never
+    # grouped entries under "Features"/"Bugfixes"/... sub-headings).
+    { directory = "change", name = "", showcontent = true },
+]
 
 [tool.mypy_strict_kwargs]
 # ``builtins.eval`` has a version-gated typeshed signature: on
@@ -413,6 +443,9 @@ ignore_names = [
     # docutils settings
     "halt_level",
     "report_level",
+    "towncrier_draft_autoversion_mode",
+    "towncrier_draft_include_empty",
+    "towncrier_draft_working_directory",
 ]
 # Duplicate some of .gitignore
 exclude = [ ".venv" ]


### PR DESCRIPTION
## Summary

This switches release changelog handling to the same towncrier-based flow used by literalizer:

- replace the manual `Next` changelog section update with `towncrier build`
- generate GitHub release notes from the same news fragments
- add the towncrier config, template, and `newsfragments/` directory
- render unreleased fragments in docs where the project has Sphinx docs
- migrate any existing `Next` entries into initial news fragments

## Validation

- `uv run --extra=release towncrier build --draft --version 2099.01.01`
- `uvx --from actionlint-py actionlint .github/workflows/release.yml`
- `uv run --extra=dev pyproject-fmt --check --no-print-diff pyproject.toml` where the repo has a dev extra
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the automated release workflow to generate tags/releases and mutate `CHANGELOG.rst` via `towncrier`, so misconfiguration could break release publishing or produce incorrect release notes.
> 
> **Overview**
> Switches releases to be driven by **Towncrier news fragments** instead of editing the `CHANGELOG.rst` `Next` section or using github-tag-action’s autogenerated changelog. The release workflow now drafts per-version GitHub release notes to `release-notes.md`, runs `towncrier build` to update `CHANGELOG.rst` (consuming fragments), and commits both the changelog and `newsfragments/` changes before tagging.
> 
> Adds Towncrier wiring across the repo: a `newsfragments/` directory, a custom Towncrier template to preserve the existing flat changelog format, and a `[tool.towncrier]` config in `pyproject.toml` (plus dev deps for `towncrier` and `sphinxcontrib-towncrier`). Documentation now includes an `unreleased` page that renders draft fragments during Sphinx builds, and `CHANGELOG.rst` is updated to include the Towncrier marker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f7ec14b81a698c4fe5db32311bba5d98d53d162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->