### PR TITLE
[codex] Add towncrier to release extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ optional-dependencies.dev = [
     "yamlfix==1.19.1",
     "zizmor==1.25.2",
 ]
-optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
+optional-dependencies.release = [ "check-wheel-contents==0.6.3", "towncrier==25.8.0" ]
 urls.Documentation = "https://adamtheturtle.github.io/sybil-extras/"
 urls.Source = "https://github.com/adamtheturtle/sybil-extras"
 


### PR DESCRIPTION
## Summary

Add `towncrier==25.8.0` to the `release` extra so the release workflow can run:

```bash
uv run --extra=release towncrier build ...
```

The previous towncrier migration added the tool for development/docs builds, but release jobs install only the `release` extra before invoking towncrier.

## Validation

- `uv lock`
- `uv run --no-dev --extra=release towncrier --version`
- repo pre-commit / pre-push hooks run by `git commit` and `git push`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts packaging metadata by adding a pinned dependency to the `release` extra, with no runtime code changes.
> 
> **Overview**
> Adds `towncrier==25.8.0` to `optional-dependencies.release` in `pyproject.toml` so release installs that use `--extra=release` can run `towncrier build` without also installing dev tooling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be213f9aec1cf63a5daa391a2a6feadd0e1469e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->