### PR TITLE
Detect invisible-code-block HTML comments in MarkdownIt/MyST parsers

### DIFF
--- a/src/sybil_extras/parsers/markdown_it/codeblock.py
+++ b/src/sybil_extras/parsers/markdown_it/codeblock.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 
 from beartype import beartype
 from markdown_it import MarkdownIt
+from markdown_it.token import Token
 from sybil import Document, Example, Lexeme, Region
 from sybil.typing import Evaluator
 
@@ -17,6 +18,17 @@ from sybil_extras.parsers._line_offsets import line_offsets
 # The info string can contain extra metadata like title="example".
 # We extract only the first word (anything that's not whitespace or backtick).
 _LANGUAGE_PATTERN = re.compile(pattern=r"^(?P<language>[^\s`]+)")
+
+# Pattern to match an ``invisible-code-block`` directive inside an HTML
+# comment. Mirrors ``sybil.parsers.markdown.codeblock.CodeBlockParser``
+# which registers ``DirectiveInHTMLCommentLexer`` with
+# ``directive=r'(invisible-)?code(-block)?'`` and ``arguments='.+'``.
+_INVISIBLE_CODE_BLOCK_PATTERN = re.compile(
+    pattern=r"^[ \t]*<!--+\s*(?:;\s*)?(?:invisible-)?code(?:-block)?:?"
+    r"[ \t]*(?P<language>\S+)[ \t]*"
+    r"(?:\n|(?=--+>))",
+)
+_HTML_COMMENT_END_PATTERN = re.compile(pattern=r"--+>")
 
 
 @beartype
@@ -63,6 +75,15 @@ class CodeBlockParser:
         offsets = line_offsets(text=document.text)
 
         for token in tokens:
+            if token.type == "html_block":
+                region = self._html_comment_region(
+                    token=token,
+                    document=document,
+                    offsets=offsets,
+                )
+                if region is not None:
+                    yield region
+                continue
             if token.type != "fence":
                 continue
 
@@ -128,3 +149,51 @@ class CodeBlockParser:
                 evaluator=self._evaluator or self.evaluate,
                 lexemes=lexemes,
             )
+
+    def _html_comment_region(
+        self,
+        *,
+        token: Token,
+        document: Document,
+        offsets: list[int],
+    ) -> Region | None:
+        """Build a region for an ``invisible-code-block`` HTML comment.
+
+        Returns ``None`` if the HTML comment is not an invisible code
+        block, or if the language filter does not match.
+        """
+        assert token.map is not None  # noqa: S101  # always set for html_block
+        content = token.content
+        match = _INVISIBLE_CODE_BLOCK_PATTERN.match(string=content)
+        if match is None:
+            return None
+        block_language = match.group("language")
+        if self._language is not None and block_language != self._language:
+            return None
+        end_match = _HTML_COMMENT_END_PATTERN.search(
+            string=content,
+            pos=match.end(),
+        )
+        if end_match is None:
+            return None
+
+        start_line, end_line = token.map
+        region_start = offsets[start_line]
+        if end_line < len(offsets):
+            region_end = offsets[end_line]
+        else:
+            region_end = len(document.text)
+
+        source = Lexeme(
+            text=content[match.end() : end_match.start()],
+            offset=match.end(),
+            line_offset=content[: match.end()].count("\n") - 1,
+        )
+        lexemes = {"language": block_language, "source": source}
+        return Region(
+            start=region_start,
+            end=region_end,
+            parsed=source,
+            evaluator=self._evaluator or self.evaluate,
+            lexemes=lexemes,
+        )

--- a/src/sybil_extras/parsers/myst_parser/codeblock.py
+++ b/src/sybil_extras/parsers/myst_parser/codeblock.py
@@ -4,16 +4,29 @@ This parser uses the myst-parser library, which extends markdown-it-py
 with MyST-specific extensions.
 """
 
+import re
 from collections.abc import Iterable
 
 from beartype import beartype
 from markdown_it.renderer import RendererHTML
+from markdown_it.token import Token
 from myst_parser.config.main import MdParserConfig
 from myst_parser.parsers.mdit import create_md_parser
 from sybil import Document, Example, Lexeme, Region
 from sybil.typing import Evaluator
 
 from sybil_extras.parsers._line_offsets import line_offsets
+
+# Pattern to match an ``invisible-code-block`` directive inside an HTML
+# comment. Mirrors ``sybil.parsers.markdown.codeblock.CodeBlockParser``
+# which registers ``DirectiveInHTMLCommentLexer`` with
+# ``directive=r'(invisible-)?code(-block)?'`` and ``arguments='.+'``.
+_INVISIBLE_CODE_BLOCK_PATTERN = re.compile(
+    pattern=r"^[ \t]*<!--+\s*(?:;\s*)?(?:invisible-)?code(?:-block)?:?"
+    r"[ \t]*(?P<language>\S+)[ \t]*"
+    r"(?:\n|(?=--+>))",
+)
+_HTML_COMMENT_END_PATTERN = re.compile(pattern=r"--+>")
 
 
 @beartype
@@ -63,81 +76,122 @@ class CodeBlockParser:
         offsets = line_offsets(text=document.text)
 
         for token in tokens:
-            if token.type != "fence":
+            if token.type == "html_block":
+                region = self._html_comment_region(
+                    token=token,
+                    document=document,
+                    offsets=offsets,
+                )
+            elif token.type == "fence":
+                region = self._fence_region(
+                    token=token,
+                    document=document,
+                    offsets=offsets,
+                )
+            else:
                 continue
+            if region is not None:
+                yield region
 
-            # MarkdownIt always provides map for fence tokens.
-            if token.map is None:  # pragma: no cover
-                # This should never happen; map is always set for fence tokens.
-                raise ValueError(token)
+    def _fence_region(
+        self,
+        *,
+        token: Token,
+        document: Document,
+        offsets: list[int],
+    ) -> Region | None:
+        """Build a region for a fenced code block token."""
+        if token.map is None:  # pragma: no cover
+            raise ValueError(token)
 
-            # Extract just the language from the info string.
-            # The info string can contain extra metadata
-            # (e.g., "python title=...").
-            # MyST directive-style blocks use the format
-            # "{directive} language" (e.g., "{code-block} python"),
-            # where the actual language is the second word.
-            info = token.info.strip()
-            words = info.split()
-            if not words:
-                block_language = ""
-            elif words[0].startswith("{"):
-                # MyST directive style: {directive-name} language
-                # e.g., "{code-block} python" -> language is "python"
-                block_language = words[1] if len(words) > 1 else ""
-            else:
-                block_language = words[0]
+        # Extract just the language from the info string. The info string
+        # can contain extra metadata (e.g., "python title=..."). MyST
+        # directive-style blocks use the format "{directive} language"
+        # (e.g., "{code-block} python"), where the actual language is the
+        # second word.
+        words = token.info.strip().split()
+        if not words:
+            block_language = ""
+        elif words[0].startswith("{"):
+            block_language = words[1] if len(words) > 1 else ""
+        else:
+            block_language = words[0]
 
-            # Filter by language if specified
-            if self._language is not None and block_language != self._language:
-                continue
+        if self._language is not None and block_language != self._language:
+            return None
 
-            start_line, end_line = token.map
+        start_line, end_line = token.map
+        region_start = offsets[start_line]
+        if end_line < len(offsets):
+            region_end = offsets[end_line] - 1
+        else:
+            region_end = len(document.text)
 
-            # Calculate character positions
-            region_start = offsets[start_line]
+        if start_line + 1 < len(offsets):
+            opening_fence_end = offsets[start_line + 1]
+        else:
+            opening_fence_end = len(document.text)
+        source_offset = opening_fence_end - region_start
 
-            # end_line is exclusive in MarkdownIt, pointing to the line
-            # after the closing fence. We want the region to end at the
-            # end of the closing fence line, not including the trailing
-            # newline. This matches Sybil's regex-based behavior.
-            if end_line < len(offsets):
-                # Get the start of the line after the block
-                next_line_start = offsets[end_line]
-                # The region end excludes the trailing newline after the
-                # closing fence.
-                region_end = next_line_start - 1
-            else:
-                region_end = len(document.text)
+        source = Lexeme(
+            text=token.content,
+            offset=source_offset,
+            line_offset=0,
+        )
+        lexemes = {"language": block_language, "source": source}
+        return Region(
+            start=region_start,
+            end=region_end,
+            parsed=source,
+            evaluator=self._evaluator or self.evaluate,
+            lexemes=lexemes,
+        )
 
-            # The source content is in token.content
-            # We need to calculate the offset within the region where
-            # the source starts.
-            if start_line + 1 < len(offsets):
-                opening_fence_end = offsets[start_line + 1]
-            else:
-                # Edge case: document ends without a newline after the
-                # fence.
-                opening_fence_end = len(document.text)
-            opening_fence_line = document.text[region_start:opening_fence_end]
-            source_offset = len(opening_fence_line)
+    def _html_comment_region(
+        self,
+        *,
+        token: Token,
+        document: Document,
+        offsets: list[int],
+    ) -> Region | None:
+        """Build a region for an ``invisible-code-block`` HTML comment.
 
-            source = Lexeme(
-                text=token.content,
-                offset=source_offset,
-                # line_offset is the number of newlines in the opening
-                # delimiter minus 1. For Markdown fenced code blocks,
-                # the opening line (e.g., "```python\n") has exactly one
-                # newline, so line_offset is always 0.
-                line_offset=0,
-            )
+        Returns ``None`` if the HTML comment is not an invisible code
+        block, or if the language filter does not match.
+        """
+        if token.map is None:  # pragma: no cover
+            raise ValueError(token)
+        content = token.content
+        match = _INVISIBLE_CODE_BLOCK_PATTERN.match(string=content)
+        if match is None:
+            return None
+        block_language = match.group("language")
+        if self._language is not None and block_language != self._language:
+            return None
+        end_match = _HTML_COMMENT_END_PATTERN.search(
+            string=content,
+            pos=match.end(),
+        )
+        if end_match is None:
+            return None
 
-            lexemes = {"language": block_language, "source": source}
+        start_line, end_line = token.map
+        region_start = offsets[start_line]
+        if end_line < len(offsets):
+            region_end = offsets[end_line]
+        else:
+            region_end = len(document.text)
 
-            yield Region(
-                start=region_start,
-                end=region_end,
-                parsed=source,
-                evaluator=self._evaluator or self.evaluate,
-                lexemes=lexemes,
-            )
+        source = Lexeme(
+            text=content[match.end() : end_match.start()],
+            offset=match.end(),
+            line_offset=content[: match.end()].count("\n") - 1,
+        )
+        lexemes = {"language": block_language, "source": source}
+        return Region(
+            start=region_start,
+            end=region_end,
+            parsed=source,
+            evaluator=self._evaluator or self.evaluate,
+            lexemes=lexemes,
+        )

--- a/tests/parsers/markdown_it/test_codeblock.py
+++ b/tests/parsers/markdown_it/test_codeblock.py
@@ -149,9 +149,7 @@ def test_invisible_code_block_html_comment(tmp_path: Path) -> None:
 
 
 def test_invisible_code_block_language_filter(tmp_path: Path) -> None:
-    """``invisible-code-block`` honors the parser's ``language``
-    filter.
-    """
+    """``invisible-code-block`` honors the ``language`` filter."""
     content = (
         "<!-- invisible-code-block python\n"
         "x = 1\n"
@@ -185,7 +183,7 @@ def test_invisible_code_block_unclosed_comment(tmp_path: Path) -> None:
     document = sybil.parse(path=test_file)
     examples = list(document.examples())
 
-    assert examples == []
+    assert not examples
 
 
 def test_invisible_code_block_no_trailing_newline(tmp_path: Path) -> None:

--- a/tests/parsers/markdown_it/test_codeblock.py
+++ b/tests/parsers/markdown_it/test_codeblock.py
@@ -126,6 +126,52 @@ def test_code_block_inside_blockquote(tmp_path: Path) -> None:
     assert examples[0].region.lexemes["language"] == "python"
 
 
+def test_invisible_code_block_html_comment(tmp_path: Path) -> None:
+    """``invisible-code-block`` HTML comments are matched like fences.
+
+    Matches the behavior of
+    ``sybil.parsers.markdown.codeblock.CodeBlockParser`` which registers
+    a ``DirectiveInHTMLCommentLexer`` alongside its fence lexer.
+    Regression test for
+    https://github.com/adamtheturtle/sybil-extras/issues/973.
+    """
+    content = "```text\n1\n```\n\n<!-- invisible-code-block text\n2\n-->\n"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="text", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert [e.parsed.text for e in examples] == ["1\n", "2\n"]
+    assert [e.region.lexemes["language"] for e in examples] == ["text", "text"]
+
+
+def test_invisible_code_block_language_filter(tmp_path: Path) -> None:
+    """``invisible-code-block`` honors the parser's ``language``
+    filter.
+    """
+    content = (
+        "<!-- invisible-code-block python\n"
+        "x = 1\n"
+        "-->\n"
+        "\n"
+        "<!-- invisible-code-block text\n"
+        "skip me\n"
+        "-->\n"
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="python", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert [e.parsed.text for e in examples] == ["x = 1\n"]
+
+
 def test_evaluator_not_none_when_omitted(tmp_path: Path) -> None:
     """When no evaluator is provided, the region still has an evaluator.
 

--- a/tests/parsers/markdown_it/test_codeblock.py
+++ b/tests/parsers/markdown_it/test_codeblock.py
@@ -172,6 +172,38 @@ def test_invisible_code_block_language_filter(tmp_path: Path) -> None:
     assert [e.parsed.text for e in examples] == ["x = 1\n"]
 
 
+def test_invisible_code_block_unclosed_comment(tmp_path: Path) -> None:
+    """An invisible-code-block HTML comment with no closing ``-->`` is
+    ignored.
+    """
+    content = "<!-- invisible-code-block text\n2\n"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="text", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert examples == []
+
+
+def test_invisible_code_block_no_trailing_newline(tmp_path: Path) -> None:
+    """An invisible-code-block HTML comment without a trailing newline is
+    still matched.
+    """
+    content = "<!-- invisible-code-block text\n2\n-->"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="text", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert [e.parsed.text for e in examples] == ["2\n"]
+
+
 def test_evaluator_not_none_when_omitted(tmp_path: Path) -> None:
     """When no evaluator is provided, the region still has an evaluator.
 

--- a/tests/parsers/myst_parser/test_codeblock.py
+++ b/tests/parsers/myst_parser/test_codeblock.py
@@ -141,9 +141,7 @@ def test_invisible_code_block_html_comment(tmp_path: Path) -> None:
 
 
 def test_invisible_code_block_language_filter(tmp_path: Path) -> None:
-    """``invisible-code-block`` honors the parser's ``language``
-    filter.
-    """
+    """``invisible-code-block`` honors the ``language`` filter."""
     content = (
         "<!-- invisible-code-block python\n"
         "x = 1\n"
@@ -177,7 +175,7 @@ def test_invisible_code_block_unclosed_comment(tmp_path: Path) -> None:
     document = sybil.parse(path=test_file)
     examples = list(document.examples())
 
-    assert examples == []
+    assert not examples
 
 
 def test_invisible_code_block_no_trailing_newline(tmp_path: Path) -> None:

--- a/tests/parsers/myst_parser/test_codeblock.py
+++ b/tests/parsers/myst_parser/test_codeblock.py
@@ -118,6 +118,52 @@ def test_code_block_inside_blockquote(tmp_path: Path) -> None:
     assert examples[0].region.lexemes["language"] == "python"
 
 
+def test_invisible_code_block_html_comment(tmp_path: Path) -> None:
+    """``invisible-code-block`` HTML comments are matched like fences.
+
+    Matches the behavior of
+    ``sybil.parsers.markdown.codeblock.CodeBlockParser`` which registers
+    a ``DirectiveInHTMLCommentLexer`` alongside its fence lexer.
+    Regression test for
+    https://github.com/adamtheturtle/sybil-extras/issues/973.
+    """
+    content = "```text\n1\n```\n\n<!-- invisible-code-block text\n2\n-->\n"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="text", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert [e.parsed.text for e in examples] == ["1\n", "2\n"]
+    assert [e.region.lexemes["language"] for e in examples] == ["text", "text"]
+
+
+def test_invisible_code_block_language_filter(tmp_path: Path) -> None:
+    """``invisible-code-block`` honors the parser's ``language``
+    filter.
+    """
+    content = (
+        "<!-- invisible-code-block python\n"
+        "x = 1\n"
+        "-->\n"
+        "\n"
+        "<!-- invisible-code-block text\n"
+        "skip me\n"
+        "-->\n"
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="python", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert [e.parsed.text for e in examples] == ["x = 1\n"]
+
+
 def test_evaluator_not_none_when_omitted(tmp_path: Path) -> None:
     """When no evaluator is provided, the region still has an evaluator.
 

--- a/tests/parsers/myst_parser/test_codeblock.py
+++ b/tests/parsers/myst_parser/test_codeblock.py
@@ -164,6 +164,38 @@ def test_invisible_code_block_language_filter(tmp_path: Path) -> None:
     assert [e.parsed.text for e in examples] == ["x = 1\n"]
 
 
+def test_invisible_code_block_unclosed_comment(tmp_path: Path) -> None:
+    """An invisible-code-block HTML comment with no closing ``-->`` is
+    ignored.
+    """
+    content = "<!-- invisible-code-block text\n2\n"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="text", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert examples == []
+
+
+def test_invisible_code_block_no_trailing_newline(tmp_path: Path) -> None:
+    """An invisible-code-block HTML comment without a trailing newline is
+    still matched.
+    """
+    content = "<!-- invisible-code-block text\n2\n-->"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="text", evaluator=NoOpEvaluator())
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    examples = list(document.examples())
+
+    assert [e.parsed.text for e in examples] == ["2\n"]
+
+
 def test_evaluator_not_none_when_omitted(tmp_path: Path) -> None:
     """When no evaluator is provided, the region still has an evaluator.
 


### PR DESCRIPTION
## Summary

Fixes #973. The MarkdownIt and MyST `CodeBlockParser` only recognized fenced code blocks, regressing downstream users (e.g. `doccmd`) that switched from `sybil.parsers.markdown.codeblock.CodeBlockParser`, which also matches `<!-- invisible-code-block ... -->` HTML comments. Both parsers now yield regions for matching HTML-comment blocks alongside fences, mirroring sybil's `DirectiveInHTMLCommentLexer(directive=r'(invisible-)?code(-block)?', arguments='.+')` behavior.

## Test plan

- [x] New regression tests in `tests/parsers/markdown_it/test_codeblock.py` and `tests/parsers/myst_parser/test_codeblock.py` covering the issue's reproduction and the `language` filter
- [x] Full markdown_it + myst_parser test suites pass (36 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted parser behavior extension with mirrored regex logic and focused regression tests; no auth, security, or infrastructure changes.
> 
> **Overview**
> Restores parity with Sybil’s markdown `CodeBlockParser` for **MarkdownIt** and **MyST** `CodeBlockParser`: they now treat `<!-- invisible-code-block … -->` (and related `code` / `code-block` comment forms) as doctest regions, not only fenced blocks.
> 
> Parsing walks `html_block` tokens, matches directive-shaped HTML comments via new regex helpers, applies the same **language** filter, and builds `Region`/`Lexeme` output like fences. The MyST parser also refactors fence handling into `_fence_region` while sharing `_html_comment_region`.
> 
> Regression tests cover mixed fence + invisible blocks, language filtering, unclosed comments, and comments without a trailing newline (issue #973).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7bc22fdf8add8382b515f02089764f3ba47037. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->