### PR TITLE
Use tuples for parametrize argvalues for pytest 9.1.0 typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,7 @@ lint.per-file-ignores."tests/**/test_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.flake8-pytest-style.parametrize-values-type = "tuple"
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
 

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -454,12 +454,12 @@ def test_empty_code_block_with_options(
 
 @pytest.mark.parametrize(
     argnames="new_content",
-    argvalues=[
+    argvalues=(
         "",
         # Code blocks in reStructuredText cannot contain just newlines.
         # Therefore we treat this as an empty code block.
         "\n\n",
-    ],
+    ),
 )
 def test_empty_code_block_write_empty(
     *,

--- a/tests/evaluators/test_multi.py
+++ b/tests/evaluators/test_multi.py
@@ -80,7 +80,7 @@ def test_multi_evaluator_raises_on_failure(rst_file: Path) -> None:
 
 @pytest.mark.parametrize(
     argnames="failure_string",
-    argvalues=["This check failed", ""],
+    argvalues=("This check failed", ""),
     ids=["non-empty", "empty"],
 )
 def test_multi_evaluator_propagates_failure_string(

--- a/tests/evaluators/test_pycon_shell_evaluator.py
+++ b/tests/evaluators/test_pycon_shell_evaluator.py
@@ -194,7 +194,7 @@ def test_no_change_leaves_file_unmodified(
 
 @pytest.mark.parametrize(
     argnames="pycon_block",
-    argvalues=[
+    argvalues=(
         pytest.param(
             textwrap.dedent(
                 text="""\
@@ -268,7 +268,7 @@ def test_no_change_leaves_file_unmodified(
             ),
             id="decorated_function",
         ),
-    ],
+    ),
 )
 def test_write_to_file_round_trip(
     *,
@@ -299,7 +299,7 @@ def test_write_to_file_round_trip(
 
 @pytest.mark.parametrize(
     argnames=("pycon_block", "expected_match"),
-    argvalues=[
+    argvalues=(
         pytest.param(
             textwrap.dedent(
                 text="""\
@@ -327,7 +327,7 @@ def test_write_to_file_round_trip(
             "appears before the first",
             id="blank_line_before_first_prompt",
         ),
-    ],
+    ),
 )
 def test_invalid_pycon_raises(
     *,

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -383,7 +383,7 @@ def test_pad(*, rst_file: Path, tmp_path: Path, use_pty_option: bool) -> None:
     assert given_file_content == expected_content
 
 
-@pytest.mark.parametrize(argnames="write_to_file", argvalues=[True, False])
+@pytest.mark.parametrize(argnames="write_to_file", argvalues=(True, False))
 def test_write_to_file_new_content_trailing_newlines(
     *,
     tmp_path: Path,
@@ -529,7 +529,7 @@ def test_write_to_file_new_content_trailing_newlines(
         assert source_file_content == original_content
 
 
-@pytest.mark.parametrize(argnames="write_to_file", argvalues=[True, False])
+@pytest.mark.parametrize(argnames="write_to_file", argvalues=(True, False))
 def test_write_to_file_new_content_no_trailing_newlines(
     *,
     tmp_path: Path,
@@ -807,7 +807,7 @@ def test_no_file_left_behind_on_interruption(
     }
 
 
-@pytest.mark.parametrize(argnames="source_newline", argvalues=["\n", "\r\n"])
+@pytest.mark.parametrize(argnames="source_newline", argvalues=("\n", "\r\n"))
 def test_newline_system(
     *,
     rst_file: Path,
@@ -842,13 +842,13 @@ def test_newline_system(
     assert includes_crlf == default_is_crlf
 
 
-@pytest.mark.parametrize(argnames="source_newline", argvalues=["\n", "\r\n"])
+@pytest.mark.parametrize(argnames="source_newline", argvalues=("\n", "\r\n"))
 @pytest.mark.parametrize(
     argnames=("given_newline", "expect_crlf"),
-    argvalues=[
+    argvalues=(
         ("\n", False),
         ("\r\n", True),
-    ],
+    ),
 )
 def test_newline_given(
     *,
@@ -957,7 +957,7 @@ def test_click_runner(*, rst_file: Path, use_pty_option: bool) -> None:
 
 @pytest.mark.parametrize(
     argnames="encoding",
-    argvalues=["utf_8", "utf_16"],
+    argvalues=("utf_8", "utf_16"),
 )
 def test_encoding(
     *,
@@ -1086,7 +1086,7 @@ def test_custom_on_modify_with_modification(
 
 @pytest.mark.parametrize(
     argnames="parser_cls",
-    argvalues=[MarkdownItCodeBlockParser, SybilMarkdownCodeBlockParser],
+    argvalues=(MarkdownItCodeBlockParser, SybilMarkdownCodeBlockParser),
     ids=["markdown_it", "sybil_markdown"],
 )
 def test_markdown_code_block_line_number(

--- a/tests/parsers/myst_parser/test_codeblock.py
+++ b/tests/parsers/myst_parser/test_codeblock.py
@@ -256,7 +256,7 @@ def test_percent_comment_does_not_break_parsing(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize(
     argnames="directive",
-    argvalues=["code-block", "code", "code-cell"],
+    argvalues=("code-block", "code", "code-cell"),
 )
 def test_myst_directive_code_block(*, tmp_path: Path, directive: str) -> None:
     """MyST directive-style code blocks are matched by language.
@@ -287,7 +287,7 @@ def test_myst_directive_code_block(*, tmp_path: Path, directive: str) -> None:
 
 @pytest.mark.parametrize(
     argnames="directive",
-    argvalues=["code-block", "code", "code-cell"],
+    argvalues=("code-block", "code", "code-cell"),
 )
 def test_myst_directive_code_block_no_language(
     *,
@@ -319,7 +319,7 @@ def test_myst_directive_code_block_no_language(
 
 @pytest.mark.parametrize(
     argnames="directive",
-    argvalues=["code-block", "code", "code-cell"],
+    argvalues=("code-block", "code", "code-cell"),
 )
 def test_myst_directive_code_block_wrong_language(
     *,

--- a/tests/parsers/test_sphinx_jinja2.py
+++ b/tests/parsers/test_sphinx_jinja2.py
@@ -20,10 +20,10 @@ from sybil_extras.parsers.rest.sphinx_jinja2 import (
 
 @pytest.mark.parametrize(
     argnames="parser_cls",
-    argvalues=[
+    argvalues=(
         pytest.param(MystSphinxJinja2Parser, id="myst"),
         pytest.param(MystParserSphinxJinja2Parser, id="myst-parser"),
-    ],
+    ),
 )
 def test_sphinx_jinja2(
     *,
@@ -79,9 +79,7 @@ def test_sphinx_jinja2(
 
 @pytest.mark.parametrize(
     argnames="parser_cls",
-    argvalues=[
-        pytest.param(RestSphinxJinja2Parser, id="rest"),
-    ],
+    argvalues=(pytest.param(RestSphinxJinja2Parser, id="rest"),),
 )
 def test_sphinx_jinja2_rst(
     *,

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -26,7 +26,7 @@ from sybil_extras.languages import (
 
 @pytest.mark.parametrize(
     argnames=("language", "value"),
-    argvalues=[
+    argvalues=(
         pytest.param(MYST, 1, id="myst-code-block"),
         pytest.param(MYST_PARSER, 8, id="myst-parser-code-block"),
         pytest.param(RESTRUCTUREDTEXT, 2, id="rest-code-block"),
@@ -35,7 +35,7 @@ from sybil_extras.languages import (
         pytest.param(MDX, 4, id="mdx-code-block"),
         pytest.param(DJOT, 5, id="djot-code-block"),
         pytest.param(NORG, 6, id="norg-code-block"),
-    ],
+    ),
 )
 def test_code_block_parser(
     *,
@@ -101,7 +101,7 @@ def test_skip_parser(
 
 @pytest.mark.parametrize(
     argnames=("language"),
-    argvalues=[
+    argvalues=(
         pytest.param(MYST, id="myst-empty"),
         pytest.param(MYST_PARSER, id="myst-parser-empty"),
         pytest.param(RESTRUCTUREDTEXT, id="rest-empty"),
@@ -109,7 +109,7 @@ def test_skip_parser(
         pytest.param(MDX, id="mdx-empty"),
         pytest.param(DJOT, id="djot-empty"),
         pytest.param(NORG, id="norg-empty"),
-    ],
+    ),
 )
 def test_code_block_empty(language: MarkupLanguage) -> None:
     """Code block builders handle empty content."""
@@ -165,11 +165,11 @@ def test_group_parser(
 
 @pytest.mark.parametrize(
     argnames=("language"),
-    argvalues=[
+    argvalues=(
         pytest.param(MYST, id="myst-jinja"),
         pytest.param(MYST_PARSER, id="myst-parser-jinja"),
         pytest.param(RESTRUCTUREDTEXT, id="rest-jinja"),
-    ],
+    ),
 )
 def test_sphinx_jinja_parser(
     *,


### PR DESCRIPTION
pytest 9.1.0 adds typed overloads for `pytest.mark.parametrize` (part of its deprecation of non-`Collection` `argvalues`). As a result, the bare *list* of two distinct classes both named `CodeBlockParser` in `test_markdown_code_block_line_number` no longer type-checks under mypy:

```
tests/evaluators/test_shell_evaluator.py:1089: error: List item 0 has incompatible type "type[CodeBlockParser]"; expected "type[object]"  [list-item]
```

mypy joins the two element types to `type[object]` (the classes are unrelated and share only `object`) and then spuriously rejects each `type[CodeBlockParser]` element. A **tuple** literal keeps a fixed-length type and sidesteps the join entirely.

To make this the repo convention, this sets ruff's `flake8-pytest-style.parametrize-values-type = "tuple"` and converts existing `parametrize` `argvalues` to tuples to match (a semantically identical, ruff-autofixed change).

The change is harmless under the currently-pinned pytest 9.0.3, so it can land ahead of the pytest bump (#1000); once merged, that Dependabot PR will rebase and go green.

Verified against pytest 9.1.0: mypy, pyright, ty, and pyrefly all clean; full ruff clean repo-wide; affected test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and lint-config changes with no production code paths affected.
> 
> **Overview**
> Aligns the test suite with **pytest 9.1+** expectations and Ruff’s **flake8-pytest-style** rule by using **tuples** instead of **lists** for `pytest.mark.parametrize(..., argvalues=...)`.
> 
> **`pyproject.toml`** sets `lint.flake8-pytest-style.parametrize-values-type = "tuple"` so new parametrizations stay consistent.
> 
> Across evaluator, parser, and language tests, `argvalues=[...]` is converted to `argvalues=(...)` with the same cases (booleans, newlines, encodings, directives, `pytest.param` entries, etc.). **`test_sphinx_jinja2_rst`** narrows its single REST parser case to a one-element tuple of `pytest.param(...)`.
> 
> No runtime or library behavior changes—only parametrization shape and lint configuration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bac1dea40b7c2cb01ee2239fe0303402a439693. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->