### PR TITLE
Remove obsolete SkipTest type ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ optional-dependencies.dev = [
     "doc8==2.0.0",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==2.1.0",
+    "mypy[faster-cache]==2.2.0",
     "mypy-strict-kwargs==2026.5.20.1",
     "prek==0.4.8",
     "pydocstringformatter==1.0.0",

--- a/src/sybil_extras/evaluators/thread_safe_skip.py
+++ b/src/sybil_extras/evaluators/thread_safe_skip.py
@@ -235,11 +235,8 @@ class ThreadSafeSkipper(Skipper):
         if decision.kind == "raise":
             # Build a fresh ``SkipTest`` per raise so concurrent threads
             # do not race on a shared ``__traceback__`` attribute. The
-            # ``type: ignore`` is needed until typeshed PR
-            # https://github.com/python/typeshed/pull/15703 reaches the
-            # bundled stubs and the project's strict-kwargs mypy plugin
-            # therefore stops rejecting the positional call.
-            raise SkipTest(str(object=decision.skip_reason))  # type: ignore[misc]
+            # skip reason is normalized through ``str``.
+            raise SkipTest(str(object=decision.skip_reason))
 
     def __call__(self, example: Example) -> None:
         """Evaluate ``example`` against this skipper."""


### PR DESCRIPTION
Bumps mypy to 2.2.0 so the bundled stubs accept the SkipTest call without a local suppression. Removes the stale typeshed PR comment and the matching type ignore from thread_safe_skip.py. Validated by the pre-commit hooks that ran during commit and push, including mypy, pyright, ty, and pyrefly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only mypy upgrade and comment/type-ignore cleanup; no functional changes to skip evaluation logic.
> 
> **Overview**
> **Bumps the dev dependency** `mypy[faster-cache]` from **2.1.0** to **2.2.0** so bundled stubs type-check the positional `SkipTest(...)` call in `thread_safe_skip.py` without a local suppression.
> 
> In **`ThreadSafeSkipper.evaluate_other_example`**, the PR **removes** `# type: ignore[misc]` on `raise SkipTest(str(object=decision.skip_reason))` and **replaces** the old typeshed-PR workaround comment with a short note that the skip reason is normalized via `str`. **Runtime skip behavior is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12fd7358b0c3c287ce7253e4ff931e85b2c097ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->