### PR TITLE
Respect conditional skips when counting groups

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -4,8 +4,44 @@ from collections.abc import Iterable, Sequence
 
 from beartype import beartype
 from sybil import Example, Region
+from sybil.evaluators.skip import If
 from sybil.region import Lexeme
 from sybil.typing import Evaluator
+
+_SKIP_MARKER_ITEM_COUNT = 2
+
+
+@beartype
+def _skip_condition_is_truthy(*, example: Example, reason: object) -> bool:
+    """Return whether a skip directive's condition applies."""
+    if not reason:
+        return True
+    if not isinstance(reason, str):
+        return True
+
+    text = reason.lstrip()
+    if not text.startswith("if"):
+        return True
+
+    condition = text[2:]
+    namespace = example.document.namespace.copy()
+    namespace["if_"] = If(default_reason=condition)
+    return bool(eval("if_" + condition, namespace))  # noqa: S307
+
+
+@beartype
+def _as_skip_marker(parsed: object) -> tuple[str, object] | None:
+    """Return a typed skip marker when ``parsed`` has the right shape."""
+    if not isinstance(parsed, tuple):
+        return None
+    values: tuple[object, ...] = (  # pyright: ignore[reportUnknownVariableType]
+        parsed
+    )
+    if len(values) != _SKIP_MARKER_ITEM_COUNT or not isinstance(
+        values[0], str
+    ):
+        return None
+    return values[0], values[1]
 
 
 @beartype
@@ -37,19 +73,30 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
     for ex in examples_sorted:
         parsed: object = ex.parsed
         # Skip markers have parsed values like ('next', None)
-        match parsed:
-            case ("next", object()):
-                skip_next = True
-            case ("start", object()):
-                in_skip_range = True
-            case ("end", object()):
+        skip_marker = _as_skip_marker(parsed=parsed)
+        if skip_marker is not None:
+            action, reason = skip_marker
+            if action == "next":
+                skip_next = _skip_condition_is_truthy(
+                    example=ex,
+                    reason=reason,
+                )
+                continue
+            if action == "start":
+                in_skip_range = _skip_condition_is_truthy(
+                    example=ex,
+                    reason=reason,
+                )
+                continue
+            if action == "end":
                 in_skip_range = False
-            case _:
-                if has_source(example=ex):
-                    non_skip_count += 1
-                    if skip_next or in_skip_range:
-                        skipped_count += 1
-                        skip_next = False
+                continue
+
+        if has_source(example=ex):
+            non_skip_count += 1
+            if skip_next or in_skip_range:
+                skipped_count += 1
+                skip_next = False
 
     return non_skip_count - skipped_count
 

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -1,5 +1,7 @@
 """Shared utilities for grouping parsers."""
 
+# pylint: disable=wrong-spelling-in-comment
+
 from collections.abc import Iterable, Sequence
 
 from beartype import beartype
@@ -26,7 +28,12 @@ def _skip_condition_is_truthy(*, example: Example, reason: object) -> bool:
     condition = text[2:]
     namespace = example.document.namespace.copy()
     namespace["if_"] = If(default_reason=condition)
-    return bool(eval("if_" + condition, namespace))  # noqa: S307
+    return bool(
+        eval(  # noqa: S307  # pylint: disable=eval-used
+            "if_" + condition,
+            namespace,
+        )
+    )
 
 
 @beartype

--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable, Sequence
 
 from beartype import beartype
 from sybil import Example, Region
-from sybil.evaluators.skip import If
+from sybil.evaluators.skip import Skipper, SkipState
 from sybil.region import Lexeme
 from sybil.typing import Evaluator
 
@@ -13,25 +13,26 @@ _SKIP_MARKER_ITEM_COUNT = 2
 
 @beartype
 def _skip_condition_is_truthy(*, example: Example, reason: object) -> bool:
-    """Return whether a skip directive's condition applies."""
-    if not reason:
-        return True
+    """Return whether a skip directive's condition applies.
+
+    Only ``if(...)`` conditions are evaluated; unconditional skips (and any
+    other reason shape) always apply.  Evaluation is delegated to Sybil's
+    own :class:`~sybil.evaluators.skip.Skipper`, so the grouping counter
+    uses exactly the same semantics as runtime skipping instead of a
+    parallel implementation.
+    """
     if not isinstance(reason, str):
         return True
-
-    text = reason.lstrip()
-    if not text.startswith("if"):
+    if not reason.lstrip().startswith("if"):
         return True
 
-    condition = text[2:]
-    namespace = example.document.namespace.copy()
-    namespace["if_"] = If(default_reason=condition)
-    return bool(
-        eval(  # noqa: S307  # pylint: disable=eval-used
-            "if_" + condition,
-            namespace,
-        )
-    )
+    skipper = Skipper(directive="skip")
+    state = SkipState()
+    try:
+        skipper.install(example=example, state=state, reason=reason)
+    finally:
+        example.document.pop_evaluator(evaluator=skipper)
+    return state.exception is not None
 
 
 @beartype

--- a/tests/parsers/test_grouping_utils.py
+++ b/tests/parsers/test_grouping_utils.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=wrong-spelling-in-comment
 
+import textwrap
 from collections.abc import Iterable
 from contextlib import suppress
 from pathlib import Path
@@ -147,11 +148,13 @@ def test_unusual_parsed_markers_do_not_break_grouping(
     parsed: object,
 ) -> None:
     """Unusual parsed marker shapes do not prevent grouping from finishing."""
-    content = """\
-.. code-block:: python
+    content = textwrap.dedent(
+        text="""\
+        .. code-block:: python
 
-   x = 1
-"""
+           x = 1
+        """,
+    )
     test_document = tmp_path / "test.rst"
     test_document.write_text(data=content, encoding="utf-8")
     evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")

--- a/tests/parsers/test_grouping_utils.py
+++ b/tests/parsers/test_grouping_utils.py
@@ -1,0 +1,56 @@
+"""Tests for shared grouping-parser utilities."""
+
+from pathlib import Path
+
+import pytest
+from sybil import Sybil
+
+from sybil_extras.evaluators.no_op import NoOpEvaluator
+from sybil_extras.languages import DirectiveBuilder, MarkupLanguage
+from sybil_extras.parsers.abstract._grouping_utils import (
+    count_expected_code_blocks,
+)
+
+
+@pytest.mark.parametrize(
+    argnames=("condition", "expected_count"),
+    argvalues=(("False", 2), ("True", 1)),
+)
+def test_conditional_skip_count(
+    *,
+    language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
+    tmp_path: Path,
+    condition: str,
+    expected_count: int,
+) -> None:
+    """Only truthy conditional skips reduce the expected block count."""
+    language, directive_builder = language_directive_builder
+    content = language.markup_separator.join(
+        [
+            language.code_block_builder(code="first", language="python"),
+            directive_builder(
+                directive="skip",
+                argument=f"next if({condition})",
+            ),
+            language.code_block_builder(code="second", language="python"),
+        ]
+    )
+    test_document = tmp_path / "test"
+    test_document.write_text(
+        data=f"{content}{language.markup_separator}",
+        encoding="utf-8",
+    )
+    document = Sybil(
+        parsers=[
+            language.code_block_parser_cls(
+                language="python",
+                evaluator=NoOpEvaluator(),
+            ),
+            language.thread_safe_skip_parser_cls(directive="skip"),
+        ]
+    ).parse(path=test_document)
+
+    assert (
+        count_expected_code_blocks(examples=document.examples())
+        == expected_count
+    )

--- a/tests/parsers/test_grouping_utils.py
+++ b/tests/parsers/test_grouping_utils.py
@@ -1,83 +1,107 @@
-"""Tests for shared grouping-parser utilities."""
+"""Public-interface tests for conditional skip counting in grouping."""
 
-# pylint: disable=import-private-name,wrong-spelling-in-comment
+# pylint: disable=wrong-spelling-in-comment
 
+from collections.abc import Iterable
+from contextlib import suppress
 from pathlib import Path
+from unittest import SkipTest
 
 import pytest
-from sybil import Document, Example, Region, Sybil
+from sybil import Document, Region, Sybil
+from sybil.parsers.rest import (
+    CodeBlockParser as RestCodeBlockParser,
+)
 
+from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
 from sybil_extras.evaluators.no_op import NoOpEvaluator
 from sybil_extras.languages import DirectiveBuilder, MarkupLanguage
-from sybil_extras.parsers.abstract._grouping_utils import (
-    _as_skip_marker,  # pyright: ignore[reportPrivateUsage]
-    _skip_condition_is_truthy,  # pyright: ignore[reportPrivateUsage]
-    count_expected_code_blocks,
-)
-
-
-def _example(*, parsed: object) -> Example:
-    """Build a minimal example for grouping utility tests."""
-    return Example(
-        document=Document(text="", path="test"),
-        line=1,
-        column=1,
-        region=Region(start=0, end=0, parsed=parsed),
-        namespace={},
-    )
+from sybil_extras.parsers.rest.group_all import GroupAllParser
 
 
 @pytest.mark.parametrize(
-    argnames="reason",
-    argvalues=(object(), "because"),
+    argnames=("condition", "include_second"),
+    argvalues=(
+        ("False", True),
+        ("True", False),
+    ),
 )
-def test_unconditional_skip_reason(*, reason: object) -> None:
-    """Non-conditional reasons always activate a skip marker."""
-    assert _skip_condition_is_truthy(
-        example=_example(parsed=("next", reason)),
-        reason=reason,
-    )
-
-
-@pytest.mark.parametrize(
-    argnames="parsed",
-    argvalues=(("next",), (1, None)),
-)
-def test_invalid_skip_marker_shape(*, parsed: tuple[object, ...]) -> None:
-    """Malformed tuples are not treated as skip markers."""
-    assert _as_skip_marker(parsed=parsed) is None
-
-
-def test_unknown_skip_action() -> None:
-    """Unknown tuple actions are ignored."""
-    assert (
-        count_expected_code_blocks(
-            examples=[_example(parsed=("unknown", None))]
-        )
-        == 0
-    )
-
-
-@pytest.mark.parametrize(
-    argnames=("condition", "expected_count"),
-    argvalues=(("False", 2), ("True", 1)),
-)
-def test_conditional_skip_count(
+def test_conditional_skip_grouping(
     *,
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
     condition: str,
-    expected_count: int,
+    include_second: bool,
 ) -> None:
-    """Only truthy conditional skips reduce the expected block count."""
+    """Only truthy conditional skips exclude the next block from a
+    group.
+    """
+    language, directive_builder = language_directive_builder
+    skip_directive = directive_builder(
+        directive="skip",
+        argument=f"next if({condition})",
+    )
+    second_block = language.code_block_builder(
+        code="second",
+        language="python",
+    )
+    content = language.markup_separator.join(
+        [
+            language.code_block_builder(code="first", language="python"),
+            skip_directive,
+            second_block,
+        ]
+    )
+    test_document = tmp_path / "test"
+    test_document.write_text(
+        data=f"{content}{language.markup_separator}",
+        encoding="utf-8",
+    )
+    evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
+    document = Sybil(
+        parsers=[
+            language.code_block_parser_cls(
+                language="python",
+                evaluator=evaluator,
+            ),
+            language.skip_parser_cls(directive="skip"),
+            language.group_all_parser_cls(
+                evaluator=evaluator,
+                pad_groups=True,
+            ),
+        ]
+    ).parse(path=test_document)
+
+    for example in document.examples():
+        with suppress(SkipTest):
+            example.evaluate()
+
+    if include_second:
+        content_between_blocks = (
+            language.markup_separator
+            + skip_directive
+            + language.markup_separator
+        )
+        num_newlines_between = content_between_blocks.count("\n")
+        padding = "\n" * (num_newlines_between + 2)
+        expected = f"first{padding}second\n"
+    else:
+        expected = "first\n"
+
+    assert document.namespace["blocks"] == [expected]
+
+
+def test_unconditional_skip_reason_grouping(
+    *,
+    language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
+    tmp_path: Path,
+) -> None:
+    """Non-conditional skip reasons still exclude the next block."""
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
             language.code_block_builder(code="first", language="python"),
-            directive_builder(
-                directive="skip",
-                argument=f"next if({condition})",
-            ),
+            directive_builder(directive="skip", argument='next "because"'),
             language.code_block_builder(code="second", language="python"),
         ]
     )
@@ -86,17 +110,75 @@ def test_conditional_skip_count(
         data=f"{content}{language.markup_separator}",
         encoding="utf-8",
     )
+    evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
     document = Sybil(
         parsers=[
             language.code_block_parser_cls(
                 language="python",
-                evaluator=NoOpEvaluator(),
+                evaluator=evaluator,
             ),
-            language.thread_safe_skip_parser_cls(directive="skip"),
+            language.skip_parser_cls(directive="skip"),
+            language.group_all_parser_cls(
+                evaluator=evaluator,
+                pad_groups=True,
+            ),
         ]
     ).parse(path=test_document)
 
-    assert (
-        count_expected_code_blocks(examples=document.examples())
-        == expected_count
-    )
+    for example in document.examples():
+        with suppress(SkipTest):
+            example.evaluate()
+
+    assert document.namespace["blocks"] == ["first\n"]
+
+
+@pytest.mark.parametrize(
+    argnames="parsed",
+    argvalues=(
+        ("next",),
+        (1, None),
+        ("unknown", None),
+        ("next", object()),
+    ),
+)
+def test_unusual_parsed_markers_do_not_break_grouping(
+    *,
+    tmp_path: Path,
+    parsed: object,
+) -> None:
+    """Unusual parsed marker shapes do not prevent grouping from finishing."""
+    content = """\
+.. code-block:: python
+
+   x = 1
+"""
+    test_document = tmp_path / "test.rst"
+    test_document.write_text(data=content, encoding="utf-8")
+    evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
+
+    def custom_parser(document: Document) -> Iterable[Region]:
+        """Yield a region with an unusual parsed value."""
+        doc_end = len(document.text)
+        yield Region(
+            start=doc_end - 1,
+            end=doc_end,
+            parsed=parsed,
+            evaluator=NoOpEvaluator(),
+            lexemes={},
+        )
+
+    document = Sybil(
+        parsers=[
+            RestCodeBlockParser(
+                language="python",
+                evaluator=evaluator,
+            ),
+            custom_parser,
+            GroupAllParser(evaluator=evaluator, pad_groups=False),
+        ]
+    ).parse(path=test_document)
+
+    for example in document.examples():
+        example.evaluate()
+
+    assert document.namespace["blocks"] == ["x = 1"]

--- a/tests/parsers/test_grouping_utils.py
+++ b/tests/parsers/test_grouping_utils.py
@@ -1,15 +1,61 @@
 """Tests for shared grouping-parser utilities."""
 
+# pylint: disable=import-private-name,wrong-spelling-in-comment
+
 from pathlib import Path
 
 import pytest
-from sybil import Sybil
+from sybil import Document, Example, Region, Sybil
 
 from sybil_extras.evaluators.no_op import NoOpEvaluator
 from sybil_extras.languages import DirectiveBuilder, MarkupLanguage
 from sybil_extras.parsers.abstract._grouping_utils import (
+    _as_skip_marker,  # pyright: ignore[reportPrivateUsage]
+    _skip_condition_is_truthy,  # pyright: ignore[reportPrivateUsage]
     count_expected_code_blocks,
 )
+
+
+def _example(*, parsed: object) -> Example:
+    """Build a minimal example for grouping utility tests."""
+    return Example(
+        document=Document(text="", path="test"),
+        line=1,
+        column=1,
+        region=Region(start=0, end=0, parsed=parsed),
+        namespace={},
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="reason",
+    argvalues=(object(), "because"),
+)
+def test_unconditional_skip_reason(*, reason: object) -> None:
+    """Non-conditional reasons always activate a skip marker."""
+    assert _skip_condition_is_truthy(
+        example=_example(parsed=("next", reason)),
+        reason=reason,
+    )
+
+
+@pytest.mark.parametrize(
+    argnames="parsed",
+    argvalues=(("next",), (1, None)),
+)
+def test_invalid_skip_marker_shape(*, parsed: tuple[object, ...]) -> None:
+    """Malformed tuples are not treated as skip markers."""
+    assert _as_skip_marker(parsed=parsed) is None
+
+
+def test_unknown_skip_action() -> None:
+    """Unknown tuple actions are ignored."""
+    assert (
+        count_expected_code_blocks(
+            examples=[_example(parsed=("unknown", None))]
+        )
+        == 0
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed

- evaluate conditional `skip: next` and `skip: start` reasons when counting expected grouped code blocks
- leave blocks targeted by falsy conditions in the expected count
- add cross-language regression coverage for both falsy and truthy conditions

## Why

Grouping finalizers used to count every skip target as skipped, even when an `if(...)` condition was falsy. That could let a finalizer run before a fall-through block was collected, producing separate blocks instead of one combined group. The shared count is used by both `GroupAllParser` and bounded `GroupedSourceParser`.

Closes #1053.

## Validation

- `uv run --extra=dev pytest -q .` (909 passed)
- `uv run --extra=dev prek run --all-files --hook-stage pre-commit`
- full pre-push hook suite, including mypy, Pyright, ty, and Pyrefly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared grouping finalization logic used by GroupAll and GroupedSource parsers; behavior shifts for documents with conditional skips but aligns with Sybil’s skip semantics and is covered by new tests.
> 
> **Overview**
> **Grouping parsers now treat conditional `skip` directives the same way runtime evaluation does** when computing how many code blocks must be collected before finalizing a group.
> 
> `count_expected_code_blocks` no longer treats every `skip: next` / `skip: start` marker as unconditional. For `if(...)` reasons it temporarily installs Sybil’s `Skipper` on the skip example and only arms skip-next or skip-range when that condition would actually skip. Falsy conditions leave the following block in the expected count, which avoids `GroupAllParser` and bounded `GroupedSourceParser` finalizing too early and splitting what should be one combined group.
> 
> Skip marker handling is refactored via `_as_skip_marker` and early `continue` for `next` / `start` / `end`, with malformed tuple shapes ignored instead of breaking the loop. New integration tests cover truthy vs falsy `next if(...)`, unconditional skip reasons, and odd parsed marker shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1da9e59d66d59876b6f35ae88ba57abf4a98f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->