### PR TITLE
Avoid retaining documents in ThreadSafeSkipper

### DIFF
--- a/src/sybil_extras/evaluators/thread_safe_skip.py
+++ b/src/sybil_extras/evaluators/thread_safe_skip.py
@@ -15,6 +15,7 @@ the result cached so concurrent evaluators all see the same decision.
 """
 
 import threading
+import weakref
 from dataclasses import dataclass
 from unittest import SkipTest
 
@@ -79,13 +80,15 @@ class ThreadSafeSkipper(Skipper):
             directive: The directive name (e.g. ``"skip"``).
         """
         super().__init__(directive=directive)
-        self._plans: dict[Document, _DocumentPlan] = {}
+        self._plans: weakref.WeakKeyDictionary[Document, _DocumentPlan] = (
+            weakref.WeakKeyDictionary()
+        )
         self._lock = threading.RLock()
 
     def _plan_for(self, document: Document) -> _DocumentPlan:
         """Return the plan for ``document``, building it under lock."""
         with self._lock:
-            plan = self._plans.get(document)
+            plan = self._plans.get(key=document)
             if plan is None:
                 plan = self._build_plan(document=document)
                 self._plans[document] = plan

--- a/tests/parsers/test_thread_safe_skip.py
+++ b/tests/parsers/test_thread_safe_skip.py
@@ -2,7 +2,9 @@
 languages.
 """
 
+import gc
 import threading
+import weakref
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -578,3 +580,39 @@ def test_get_skipper_returns_thread_safe(
     parser = language.thread_safe_skip_parser_cls(directive="custom-skip")
     skipper = parser.get_skipper()
     assert isinstance(skipper, ThreadSafeSkipper)
+
+
+def test_completed_document_is_not_retained(
+    *,
+    language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
+    tmp_path: Path,
+) -> None:
+    """The reusable skip parser does not retain completed documents."""
+    language, directive_builder = language_directive_builder
+    content = language.markup_separator.join(
+        [
+            directive_builder(directive="custom-skip", argument="next"),
+            language.code_block_builder(code="x = 1", language="python"),
+        ]
+    )
+    test_document = tmp_path / "test"
+    test_document.write_text(
+        data=f"{content}{language.markup_separator}",
+        encoding="utf-8",
+    )
+    fixture = _build_sybil(
+        language=language,
+        directive_name="custom-skip",
+        code_block_evaluator=PythonEvaluator(),
+    )
+    document = fixture.sybil.parse(path=test_document)
+    example: Example | None = None
+    for example in document.examples():
+        example.evaluate()
+
+    document_reference = weakref.ref(document)
+    example = None
+    del document
+    gc.collect()
+
+    assert document_reference() is None


### PR DESCRIPTION
## What changed

- store per-document skip plans in a `WeakKeyDictionary`
- keep all cache access under the existing re-entrant lock
- add cross-language regression coverage proving a completed document can be collected while the reusable parser remains alive

## Why

`ThreadSafeSkipper` used a normal dictionary keyed by `Document`, retaining every parsed document and all of its text, regions, and namespace for as long as the parser lived. The cached plan does not point back to its document, so weak keys remove the unbounded retention without changing skip decisions.

Closes #1054.

## Validation

- `uv run --extra=dev pytest -q .` (898 passed)
- `uv run --extra=dev prek run --all-files --hook-stage pre-commit`
- full pre-push hook suite, including mypy, Pyright, ty, and Pyrefly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to cache storage with no skip-semantics changes; weak keys only affect memory retention.
> 
> **Overview**
> **`ThreadSafeSkipper`** no longer keeps every parsed **`Document`** alive for the lifetime of a reusable skip parser. Per-document skip plans are stored in a **`weakref.WeakKeyDictionary`** instead of a plain **`dict`**, so plans drop away when nothing else references the document; locking and plan-building behavior stay the same.
> 
> A parameterized regression test parses and evaluates a document, drops the last reference, runs **`gc.collect()`**, and asserts the document is collectable while the parser fixture remains in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7fd178ed41db3f0098ed4c725a40c685e9c48d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->