### PR TITLE
Require Djot closing fences to end the line

### DIFF
--- a/src/sybil_extras/parsers/djot/codeblock.py
+++ b/src/sybil_extras/parsers/djot/codeblock.py
@@ -26,7 +26,12 @@ def _match_closes_existing(current: Match[str], existing: Match[str]) -> bool:
     same_type = current_fence[0] == existing_fence[0]
     sufficient_length = len(current_fence) >= len(existing_fence)
     same_prefix = current.group("prefix") == existing.group("prefix")
-    return same_type and sufficient_length and same_prefix
+    line_end = current.string.find("\n", current.end())
+    if line_end == -1:
+        line_end = len(current.string)
+    trailing_text = current.string[current.end() : line_end]
+    fence_only = not trailing_text.strip(" \t\r")
+    return same_type and sufficient_length and same_prefix and fence_only
 
 
 @beartype

--- a/tests/parsers/djot/test_codeblock.py
+++ b/tests/parsers/djot/test_codeblock.py
@@ -31,6 +31,22 @@ def test_fenced_code_block_outside_blockquote() -> None:
     assert region.parsed == "x = 1\n"
 
 
+def test_backticks_with_trailing_text_are_content() -> None:
+    """A backtick line with trailing text does not close the block."""
+    (region,) = _parse(
+        text=dedent(
+            text="""\
+            ```python
+            ```not-a-closing-fence
+            still_code
+            ```
+            """,
+        )
+    )
+
+    assert region.parsed == "```not-a-closing-fence\nstill_code\n"
+
+
 def test_code_block_in_blockquote_without_closing_fence() -> None:
     """A Djot code block can be closed by the end of its blockquote."""
     (region,) = _parse(


### PR DESCRIPTION
## What changed

- reject closing-fence candidates that have non-whitespace text after the backticks
- preserve candidate lines with trailing text as code-block content
- add a regression for a backtick-prefixed content line followed by more code

## Why

The Djot lexer previously accepted any line beginning with enough backticks as a closer. Djot closing fences must occupy the line apart from optional whitespace, so content such as `````not-a-closing-fence`` was incorrectly truncated.

Closes #1055.

## Validation

- `uv run --extra=dev pytest -q .` (888 passed)
- `uv run --extra=dev prek run --all-files --hook-stage pre-commit`
- full pre-push hook suite, including mypy, Pyright, ty, and Pyrefly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized lexer rule change in Djot code-block parsing with a regression test; no auth, data, or broad API impact.
> 
> **Overview**
> Djot fenced code blocks no longer treat a backtick run as a **closing fence** when the same line has non-whitespace after the ticks. **`_match_closes_existing`** now checks the remainder of the line (through newline or EOF) and only accepts a closer when that tail is empty aside from spaces/tabs/carriage returns.
> 
> Lines like `` ```not-a-closing-fence `` inside a block stay **code content** until a real closing fence is found, matching Djot’s rule that closers occupy the line alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6989f9eee30b107e5393dd005c5547d43a6fea4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->