### PR TITLE
Exclude MyST directive options from executable code

### DIFF
--- a/src/sybil_extras/parsers/myst_parser/codeblock.py
+++ b/src/sybil_extras/parsers/myst_parser/codeblock.py
@@ -16,6 +16,9 @@ from sybil import Document, Example, Lexeme, Region
 from sybil.typing import Evaluator
 
 from sybil_extras.parsers._line_offsets import line_offsets
+from sybil_extras.parsers.myst_parser.sphinx_jinja2 import (
+    parse_options_and_body,
+)
 
 # Pattern to match an ``invisible-code-block`` directive inside an HTML
 # comment. Mirrors ``sybil.parsers.markdown.codeblock.CodeBlockParser``
@@ -110,9 +113,10 @@ class CodeBlockParser:
         # (e.g., "{code-block} python"), where the actual language is the
         # second word.
         words = token.info.strip().split()
+        is_directive = bool(words and words[0].startswith("{"))
         if not words:
             block_language = ""
-        elif words[0].startswith("{"):
+        elif is_directive:
             block_language = words[1] if len(words) > 1 else ""
         else:
             block_language = words[0]
@@ -127,14 +131,23 @@ class CodeBlockParser:
         else:
             region_end = len(document.text)
 
-        if start_line + 1 < len(offsets):
-            opening_fence_end = offsets[start_line + 1]
+        source_text = token.content
+        removed_prefix = ""
+        if is_directive:
+            _, source_text = parse_options_and_body(content=token.content)
+            source_length = len(source_text)
+            removed_length = len(token.content) - source_length
+            removed_prefix = token.content[:removed_length]
+
+        source_start_line = start_line + 1 + removed_prefix.count("\n")
+        if source_start_line < len(offsets):
+            opening_fence_end = offsets[source_start_line]
         else:
             opening_fence_end = len(document.text)
         source_offset = opening_fence_end - region_start
 
         source = Lexeme(
-            text=token.content,
+            text=source_text,
             offset=source_offset,
             line_offset=0,
         )

--- a/src/sybil_extras/parsers/myst_parser/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/myst_parser/sphinx_jinja2.py
@@ -14,11 +14,11 @@ from sybil.typing import Evaluator
 
 from sybil_extras.parsers._line_offsets import line_offsets
 
-_OPTION_PATTERN = re.compile(pattern=r"^:(?P<key>\w+):\s*(?P<value>.*)$")
+_OPTION_PATTERN = re.compile(pattern=r"^:(?P<key>[\w-]+):\s*(?P<value>.*)$")
 
 
 @beartype
-def _parse_options_and_body(
+def parse_options_and_body(
     content: str,
 ) -> tuple[dict[str, str], str]:
     """Separate options from body in directive content."""
@@ -92,7 +92,7 @@ class SphinxJinja2Parser:
             else:
                 region_end = len(document.text)
 
-            options, body = _parse_options_and_body(
+            options, body = parse_options_and_body(
                 content=token.content,
             )
 

--- a/tests/parsers/myst_parser/test_codeblock.py
+++ b/tests/parsers/myst_parser/test_codeblock.py
@@ -289,6 +289,40 @@ def test_myst_directive_code_block(*, tmp_path: Path, directive: str) -> None:
     argnames="directive",
     argvalues=("code-block", "code", "code-cell"),
 )
+def test_myst_directive_code_block_options(
+    *,
+    tmp_path: Path,
+    directive: str,
+) -> None:
+    """MyST directive options are excluded from executable source."""
+    content = textwrap.dedent(
+        text=f"""\
+        ```{{{directive}}} python
+        :linenos:
+        :lineno-start: 3
+        :emphasize-lines: 1
+        :caption: Example
+
+        print('hello')
+        ```
+        """,
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language="python", evaluator=NoOpEvaluator())
+    document = Sybil(parsers=[parser]).parse(path=test_file)
+    (example,) = document.examples()
+
+    assert example.parsed.text == "print('hello')\n"
+    expected_offset = content.index("print('hello')")
+    assert example.region.start + example.parsed.offset == expected_offset
+
+
+@pytest.mark.parametrize(
+    argnames="directive",
+    argvalues=("code-block", "code", "code-cell"),
+)
 def test_myst_directive_code_block_no_language(
     *,
     tmp_path: Path,


### PR DESCRIPTION
## What changed

- reuse the MyST directive option/body parser for directive-style code fences
- support hyphenated option names such as `lineno-start` and `emphasize-lines`
- exclude options and their separator from executable source
- align the source lexeme offset with the first line of actual code
- cover `{code-block}`, `{code}`, and `{code-cell}`

## Why

`myst_parser.CodeBlockParser` extracted the directive language correctly but passed raw token content to evaluators. Valid MyST options therefore became invalid Python source, and source locations pointed before the executable body.

Closes #1056.

## Validation

- `uv run --extra=dev pytest -q .` (890 passed)
- `uv run --extra=dev prek run --all-files --hook-stage pre-commit`
- full pre-push hook suite, including mypy, Pyright, ty, and Pyrefly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to MyST code-block parsing and a shared option parser; behavior is covered by new tests with no auth or data-path impact.
> 
> **Overview**
> Fixes MyST **directive-style** fenced code blocks (`{code-block}`, `{code}`, `{code-cell}`) so evaluators receive only the real code body, not Sphinx/MyST option lines like `:linenos:` or `:lineno-start:`.
> 
> `CodeBlockParser` now reuses **`parse_options_and_body`** (shared with the Jinja directive parser) to strip the option prefix and recomputes the source **lexeme offset** from the first executable line. Option keys may include **hyphens** (`[\w-]+`), and the helper is **public** so both parsers import the same logic.
> 
> Adds parametrized tests that assert parsed text and document offsets for blocks with multiple options across all three code directives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45fa1007d7b30c81ffd97a41240a4c0bb980cb69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->