### PR TITLE
Send EOF to shell command stdin

### DIFF
--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -71,7 +71,7 @@ def run_command(
             args=command,
             stdout=stdout,
             stderr=stderr,
-            stdin=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             env=env,
             close_fds=True,
         ) as process:
@@ -110,7 +110,7 @@ def run_command(
             args=command,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            stdin=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
             env=env,
         ) as process:
             if (

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -156,26 +156,25 @@ def test_output_shown(
     assert outerr.err == expected_stderr
 
 
-def test_command_reading_stdin_receives_eof(*, use_pty_option: bool) -> None:
+def test_command_reading_stdin_receives_eof(
+    *,
+    rst_file: Path,
+    use_pty_option: bool,
+) -> None:
     """Commands reading standard input receive EOF instead of hanging."""
-    script = textwrap.dedent(
-        text=f"""\
-        import sys
-
-        from sybil_extras.evaluators._subprocess_utils import run_command
-
-        run_command(
-            command=[sys.executable, "-c", "import sys; sys.stdin.read()"],
-            use_pty={use_pty_option!r},
-        )
-        """,
+    evaluator = ShellCommandEvaluator(
+        args=[sys.executable, "-c", "import sys; sys.stdin.read()"],
+        temp_file_path_maker=make_temp_file_path,
+        pad_file=False,
+        write_to_file=False,
+        use_pty=use_pty_option,
     )
+    parser = CodeBlockParser(language="python", evaluator=evaluator)
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=rst_file)
+    (example,) = document.examples()
 
-    subprocess.run(
-        args=[sys.executable, "-c", script],
-        check=True,
-        timeout=5,
-    )
+    example.evaluate()
 
 
 def test_rm(

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -156,6 +156,28 @@ def test_output_shown(
     assert outerr.err == expected_stderr
 
 
+def test_command_reading_stdin_receives_eof(*, use_pty_option: bool) -> None:
+    """Commands reading stdin receive EOF instead of hanging."""
+    script = textwrap.dedent(
+        text=f"""\
+        import sys
+
+        from sybil_extras.evaluators._subprocess_utils import run_command
+
+        run_command(
+            command=[sys.executable, "-c", "import sys; sys.stdin.read()"],
+            use_pty={use_pty_option!r},
+        )
+        """,
+    )
+
+    subprocess.run(
+        args=[sys.executable, "-c", script],
+        check=True,
+        timeout=5,
+    )
+
+
 def test_rm(
     *,
     rst_file: Path,

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -157,7 +157,7 @@ def test_output_shown(
 
 
 def test_command_reading_stdin_receives_eof(*, use_pty_option: bool) -> None:
-    """Commands reading stdin receive EOF instead of hanging."""
+    """Commands reading standard input receive EOF instead of hanging."""
     script = textwrap.dedent(
         text=f"""\
         import sys


### PR DESCRIPTION
## What changed

- connect child stdin to `DEVNULL` in both PTY and pipe execution modes
- add timeout-protected regressions for commands that read stdin in both modes

## Why

`run_command()` opened stdin pipes but had no API for supplying input and never closed those pipes. Commands waiting for EOF therefore blocked forever while the evaluator waited for their output streams. `DEVNULL` supplies immediate EOF and matches the evaluator's no-input contract.

Closes #1057.

## Validation

- `uv run --extra=dev pytest -q .` (889 passed)
- `uv run --extra=dev prek run --all-files --hook-stage pre-commit`
- full pre-push hook suite, including mypy, Pyright, ty, and Pyrefly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small subprocess wiring change aligned with the evaluator’s no-stdin-input contract; regression test covers both execution modes.
> 
> **Overview**
> Fixes **indefinite hangs** when doctest shell commands read from stdin by wiring child **stdin to `subprocess.DEVNULL`** in `run_command()` for both **PTY** and **pipe** execution paths (replacing an open `stdin=PIPE` that was never fed or closed).
> 
> Adds **`test_command_reading_stdin_receives_eof`**, parametrized over PTY vs non-PTY, so `sys.stdin.read()` completes instead of blocking the evaluator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62f2f6fd6f33b387f9cd9fe2b62f6d8fd6686ec6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->