### PR TITLE
Preserve concurrent code block edits

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -9,11 +9,80 @@ reStructuredText.
 
 import re
 import textwrap
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from beartype import beartype
-from sybil import Example
+from sybil import Document, Example
 from sybil.typing import Evaluator
+
+
+@dataclass
+class _CapturedValue:
+    """A namespace value isolated to one evaluator call."""
+
+    value: object | None = None
+
+
+class _WriterLocal(threading.local):
+    """Per-thread stack of namespace captures."""
+
+    def __init__(self) -> None:
+        """Initialize an empty capture stack for the current thread."""
+        self.captures: dict[str, list[_CapturedValue]] = {}
+
+
+class _WriterNamespace(dict[str, object]):
+    """A document namespace with isolated writer result slots."""
+
+    def __init__(self, *, namespace: dict[str, object]) -> None:
+        """Initialize from an existing document namespace."""
+        super().__init__(namespace)
+        self._local = _WriterLocal()
+        self._capture_lock = threading.Lock()
+        self.write_lock = threading.RLock()
+
+    def _active_capture(self, *, key: str) -> _CapturedValue | None:
+        """Return this thread's innermost capture for ``key``."""
+        captures = self._local.captures.get(key, ())
+        return captures[-1] if captures else None
+
+    @contextmanager
+    def capture(self, *, key: str) -> Generator[_CapturedValue]:
+        """Capture writes to ``key`` in the current thread."""
+        with self._capture_lock:
+            captured = _CapturedValue(value=super().pop(key, None))
+        captures = self._local.captures.setdefault(key, [])
+        captures.append(captured)
+        try:
+            yield captured
+        finally:
+            captures.pop()
+
+    def __setitem__(self, key: str, value: object) -> None:
+        """Store captured writer content separately for each thread."""
+        capture = self._active_capture(key=key)
+        if capture is None:
+            super().__setitem__(key, value)
+            return
+        capture.value = value
+
+
+_NAMESPACE_INSTALL_LOCK = threading.Lock()
+
+
+@beartype
+def _writer_namespace(*, document: Document) -> _WriterNamespace:
+    """Return the shared writer-aware namespace for ``document``."""
+    with _NAMESPACE_INSTALL_LOCK:
+        namespace = document.namespace
+        if not isinstance(namespace, _WriterNamespace):
+            namespace = _WriterNamespace(namespace=namespace)
+            document.namespace = namespace
+        return namespace
 
 
 @beartype
@@ -231,19 +300,24 @@ class CodeBlockWriterEvaluator:
         that formatters or auto-fixers can update files even when other
         checks (like linter checks) fail.
         """
-        try:
-            self._evaluator(example)
-        finally:
-            modified_content = example.document.namespace.get(
-                self._namespace_key
-            )
-            if modified_content is not None:
-                # Clear the namespace key to prevent stale data affecting
-                # subsequent examples.
-                del example.document.namespace[self._namespace_key]
-                if modified_content != example.parsed:
-                    _overwrite_example_content(
-                        example=example,
-                        new_content=modified_content,
-                        encoding=self._encoding,
-                    )
+        namespace = _writer_namespace(document=example.document)
+        with namespace.capture(key=self._namespace_key) as captured:
+            try:
+                self._evaluator(example)
+            finally:
+                modified_content = captured.value
+                if modified_content is not None and not isinstance(
+                    modified_content, str
+                ):
+                    msg = "Modified code block content must be a string"
+                    raise TypeError(msg)
+                if (
+                    modified_content is not None
+                    and modified_content != example.parsed
+                ):
+                    with namespace.write_lock:
+                        _overwrite_example_content(
+                            example=example,
+                            new_content=modified_content,
+                            encoding=self._encoding,
+                        )

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -1,6 +1,7 @@
 """Tests for the code_block_writer module."""
 
 import textwrap
+import threading
 from pathlib import Path
 
 import pytest
@@ -19,6 +20,74 @@ from sybil_extras.languages import (
     RESTRUCTUREDTEXT,
     MarkupLanguage,
 )
+
+
+def test_concurrent_writes_keep_each_edit(tmp_path: Path) -> None:
+    """Concurrent evaluations retain both code block edits."""
+    content = textwrap.dedent(
+        text="""\
+        ```python
+        first
+        ```
+
+        ```python
+        second
+        ```
+        """
+    )
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(data=content, encoding="utf-8")
+    first_ready = threading.Event()
+    release_first = threading.Event()
+
+    def modifying_evaluator(example: Example) -> None:
+        """Uppercase the block after arranging an overlapping call."""
+        source = str(object=example.parsed)
+        example.document.namespace["modified_content"] = source.upper()
+        if source.strip() == "first":
+            first_ready.set()
+            assert release_first.wait(timeout=5)
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = MARKDOWN.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    first, second = document.examples()
+    first_thread = threading.Thread(target=first.evaluate)
+
+    first_thread.start()
+    assert first_ready.wait(timeout=5)
+    second.evaluate()
+    release_first.set()
+    first_thread.join(timeout=5)
+
+    assert not first_thread.is_alive()
+    expected = content.replace("first", "FIRST").replace("second", "SECOND")
+    assert source_file.read_text(encoding="utf-8") == expected
+    document.namespace["ordinary"] = "shared"
+    assert document.namespace["ordinary"] == "shared"
+
+
+def test_non_string_modified_content_raises(tmp_path: Path) -> None:
+    """Modified code block content must remain a string."""
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(data="```python\noriginal\n```\n", encoding="utf-8")
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store an invalid modified content value."""
+        example.document.namespace["modified_content"] = 1
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = MARKDOWN.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    (example,) = Sybil(parsers=[parser]).parse(path=source_file).examples()
+
+    with pytest.raises(expected_exception=TypeError, match="must be a string"):
+        example.evaluate()
 
 
 def test_writes_modified_content(


### PR DESCRIPTION
## Summary

- isolate each concurrent evaluator call's modified-content result
- serialize document offset updates and file writes per document
- add a deterministic overlapping-evaluation regression and retain explicit type validation

## Testing

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (889 passed, 100% coverage)
- Ruff, formatting, Pylint, Mypy, Pyright, Pyright verify-types, Ty, and Pyrefly

Closes #1058

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrency and persistence behavior for a core doc-mutation path; risk is mitigated by locks and targeted tests but overlapping evaluation was previously unsafe.
> 
> **Overview**
> **`CodeBlockWriterEvaluator` no longer loses edits when multiple examples run at once.** The document namespace is upgraded to a writer-aware wrapper that **isolates each evaluation’s `modified_content` slot per thread** (nested captures via a per-thread stack), while ordinary namespace keys still behave like a normal dict.
> 
> **Disk and in-memory region updates are serialized per document** with a re-entrant `write_lock` around `_overwrite_example_content`, so overlapping evaluations don’t corrupt offsets or the source file.
> 
> **Validation:** non-string values written to the modified-content key now raise **`TypeError`** before persisting. Tests add an overlapping two-thread regression and the type-error case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb636419a7542fbe16f6e8596f154b4ae4c46327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->