### PR TITLE
Handle empty tilde fenced code blocks

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -88,7 +88,7 @@ def _get_modified_region_text(
         replace_new_prefix = ""
     # This is a break of the abstraction, - we really should not have
     # to know about markup language specifics here.
-    elif original_region_text.endswith("```"):
+    elif original_region_text.endswith(("```", "~~~")):
         # Markdown or MyST
         within_code_block_indent_prefix = code_block_indent_prefix
         replace_old_not_indented = "\n"

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -338,6 +338,30 @@ def test_empty_code_block_write_content(
     assert source_file.read_text(encoding="utf-8") == expected_content
 
 
+def test_empty_tilde_fenced_block(tmp_path: Path) -> None:
+    """Content is inserted without indentation inside a tilde fence."""
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(data="~~~python\n~~~\n", encoding="utf-8")
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store modified content in the namespace."""
+        example.document.namespace["modified_content"] = "inserted"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = MARKDOWN_IT.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == (
+        "~~~python\ninserted\n~~~\n"
+    )
+
+
 def test_empty_code_block_with_options(
     *,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- recognize tilde fences as Markdown-style empty blocks when inserting content
- keep inserted content flush with the fence rather than applying reStructuredText indentation
- add a Markdown-it regression for the reported round trip

## Testing

- 888 tests passed with 100% coverage
- Ruff, formatting, Pylint, Mypy, Pyright, Pyright verify-types, Ty, and Pyrefly

Closes #1059

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-branch change in markup-specific empty-block detection plus a test; no auth, data, or broad API impact.
> 
> **Overview**
> Fixes **round-trip writes** into **empty tilde-fenced** Markdown blocks (`~~~`) by treating a region that ends with `~~~` the same as one ending with backtick fences.
> 
> In `code_block_writer._get_modified_region_text`, empty blocks that close with `~~~` now follow the Markdown/MyST insertion path (flush content, no extra RST-style indent) instead of falling through to reStructuredText rules.
> 
> Adds a **Markdown-it** regression test that inserts into `~~~python\n~~~\n` and expects `inserted` on its own line inside the fence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b6fa054ed61e7b65b70fe9f1992b0758e674c22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->