### PR TITLE
Reject unsafe grouped code block writes

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -117,6 +117,12 @@ def _get_modified_region_text(
         replacement_text += "\n"
 
     text_to_replace_index = original_region_text.rfind(indented_example_parsed)
+    if text_to_replace_index < 0:
+        msg = (
+            "Parsed code is not contiguous in its source region; "
+            "grouped examples cannot be written"
+        )
+        raise ValueError(msg)
     text_before_replacement = original_region_text[:text_to_replace_index]
     text_after_replacement = original_region_text[
         text_to_replace_index + len(indented_example_parsed) :

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -19,6 +19,55 @@ from sybil_extras.languages import (
     RESTRUCTUREDTEXT,
     MarkupLanguage,
 )
+from sybil_extras.parsers.markdown.group_all import GroupAllParser
+
+
+def test_grouped_example_write_is_rejected_without_corruption(
+    tmp_path: Path,
+) -> None:
+    """A non-contiguous grouped region fails before writing the file."""
+    content = textwrap.dedent(
+        text="""\
+        ```python
+        first
+        ```
+
+        ```python
+        second
+        ```
+        """
+    )
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(data=content, encoding="utf-8")
+
+    def modifying_evaluator(example: Example) -> None:
+        """Uppercase the grouped source."""
+        example.document.namespace["modified_content"] = str(
+            object=example.parsed
+        ).upper()
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    document = Sybil(
+        parsers=[
+            MARKDOWN.code_block_parser_cls(
+                language="python",
+                evaluator=NoOpEvaluator(),
+            ),
+            GroupAllParser(evaluator=writer_evaluator, pad_groups=False),
+        ]
+    ).parse(path=source_file)
+
+    examples = list(document.examples())
+    for example in examples[:-1]:
+        example.evaluate()
+
+    with pytest.raises(
+        expected_exception=ValueError,
+        match="grouped examples cannot be written",
+    ):
+        examples[-1].evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == content
 
 
 def test_writes_modified_content(

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -22,10 +22,19 @@ from sybil_extras.languages import (
 from sybil_extras.parsers.markdown.group_all import GroupAllParser
 
 
-def test_grouped_example_write_is_rejected_without_corruption(
+def test_write_back_of_group_spanning_multiple_blocks_is_rejected(
     tmp_path: Path,
 ) -> None:
-    """A non-contiguous grouped region fails before writing the file."""
+    """Writing back a group made of separate code blocks is rejected.
+
+    ``GroupAllParser`` combines several code blocks into one example whose
+    parsed source is the concatenation of every block's code.  In the
+    document those blocks are separated by fences and blank lines, so the
+    combined code never appears as one contiguous run of text in the
+    source.  There is therefore nowhere to slice the replacement in, and
+    attempting to write it back would corrupt the file.  The writer raises
+    instead, and the file is left unchanged.
+    """
     content = textwrap.dedent(
         text="""\
         ```python


### PR DESCRIPTION
## Summary

- detect when parsed code is not contiguous within its source region
- reject grouped writer composition explicitly before slicing or writing
- add the reported GroupAllParser regression and verify the file remains unchanged

## Testing

- 888 tests passed with 100% coverage
- Ruff, formatting, Pylint, Mypy, Pyright, Pyright verify-types, Ty, and Pyrefly

Closes #1060

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small guard in the writer path plus tests; normal single-block writes are unchanged when `rfind` succeeds.
> 
> **Overview**
> **`CodeBlockWriterEvaluator`** now refuses to write back when the indented parsed text cannot be found as a single contiguous substring in the example’s source region. That case arises with **`GroupAllParser`**, where `example.parsed` is the concatenation of several fenced blocks separated by markup—slicing would corrupt the file, so a **`ValueError`** is raised with a message that grouped examples cannot be written.
> 
> A regression test drives two adjacent Python fences through **`GroupAllParser`** + **`CodeBlockWriterEvaluator`**, expects that error on the grouped example, and asserts the on-disk file is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f6c49cb9ea7865a85e380d23765df941746654c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->