### PR TITLE
Preserve source newline convention

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -17,6 +17,16 @@ from sybil.typing import Evaluator
 
 
 @beartype
+def _get_source_newline(*, path: Path, encoding: str | None) -> str | None:
+    """Return the first newline convention used by a source file."""
+    with path.open(mode="r", encoding=encoding, newline="") as source_file:
+        source_text = source_file.read()
+
+    newline_match = re.search(pattern=r"\r\n|\r|\n", string=source_text)
+    return newline_match.group() if newline_match else None
+
+
+@beartype
 def _get_within_code_block_indentation_prefix(example: Example) -> str:
     """Get the indentation of the parsed code in the example."""
     first_line = str(object=example.parsed).split(sep="\n", maxsplit=1)[0]
@@ -164,6 +174,8 @@ def _overwrite_example_content(
     )
 
     if modified_region_text != original_region_text:
+        path = Path(example.path)
+        source_newline = _get_source_newline(path=path, encoding=encoding)
         existing_file_content = example.document.text
         modified_document_content = (
             existing_file_content[: example.region.start]
@@ -180,9 +192,10 @@ def _overwrite_example_content(
         for region in subsequent_regions:
             region.start += offset
             region.end += offset
-        Path(example.path).write_text(
+        path.write_text(
             data=modified_document_content,
             encoding=encoding,
+            newline=source_newline,
         )
 
 

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -141,6 +141,32 @@ def test_writes_modified_content(
     assert source_file.read_text(encoding="utf-8") == expected_content
 
 
+def test_preserves_source_newline_convention(tmp_path: Path) -> None:
+    """Writing a code block preserves CRLF newlines in the source file."""
+    source_file = tmp_path / "source_file.md"
+    source_file.write_bytes(
+        data=b"before\r\n\r\n```python\r\nfirst\r\n```\r\n\r\nafter\r\n"
+    )
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store modified content in the namespace."""
+        example.document.namespace["modified_content"] = "FIRST\n"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = MARKDOWN_IT.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert source_file.read_bytes() == (
+        b"before\r\n\r\n```python\r\nFIRST\r\n```\r\n\r\nafter\r\n"
+    )
+
+
 def test_writes_on_evaluator_exception(tmp_path: Path) -> None:
     """When the wrapped evaluator raises an exception, modifications are
     still


### PR DESCRIPTION
## Summary
- detect the source document’s existing newline convention before rewriting it
- use that convention when persisting modified code blocks
- add a CRLF regression covering unrelated surrounding content

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1061

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to how files are written after code-block updates; behavior improves fidelity with no auth or data-path impact.
> 
> **Overview**
> Fixes code-block rewrites **normalizing CRLF (or mixed) line endings to LF** on save by detecting the document’s existing newline style and passing it to `Path.write_text`.
> 
> Adds `_get_source_newline`, which reads the source file in universal-newline mode and uses the first `\r\n`, `\r`, or `\n` found. **`CodeBlockWriterEvaluator`** now applies that when persisting updates after in-memory region edits.
> 
> A **CRLF regression test** checks that surrounding content and line endings stay intact when only the fenced block body changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 183a3eb1503593edc3af02c893f6283e3deb6314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->