### PR TITLE
Return wrapped evaluator failures

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -223,7 +223,7 @@ class CodeBlockWriterEvaluator:
         self._namespace_key = namespace_key
         self._encoding = encoding
 
-    def __call__(self, example: Example) -> None:
+    def __call__(self, example: Example) -> str | None:
         """Run the wrapped evaluator and write any modifications back.
 
         If the wrapped evaluator raises an exception, modifications are
@@ -232,7 +232,7 @@ class CodeBlockWriterEvaluator:
         checks (like linter checks) fail.
         """
         try:
-            self._evaluator(example)
+            return self._evaluator(example)
         finally:
             modified_content = example.document.namespace.get(
                 self._namespace_key

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 from sybil import Example, Sybil
+from sybil.example import SybilFailure
 
 from sybil_extras.evaluators.code_block_writer import CodeBlockWriterEvaluator
 from sybil_extras.evaluators.no_op import NoOpEvaluator
@@ -195,6 +196,37 @@ def test_writes_on_evaluator_exception(tmp_path: Path) -> None:
     updated_content = source_file.read_text(encoding="utf-8")
     assert updated_content != original_content
     assert "modified" in updated_content
+
+
+def test_returns_wrapped_evaluator_failure(tmp_path: Path) -> None:
+    """A textual failure from the wrapped evaluator is returned to
+    Sybil.
+    """
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(
+        data="```python\npass\n```\n",
+        encoding="utf-8",
+    )
+
+    def failing_evaluator(example: Example) -> str:
+        """Return a textual failure without modifying the example."""
+        del example
+        return "formatter reported a failure"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=failing_evaluator)
+    parser = MARKDOWN.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    assert writer_evaluator(example) == "formatter reported a failure"
+    with pytest.raises(
+        expected_exception=SybilFailure,
+        match="formatter reported a failure",
+    ):
+        example.evaluate()
 
 
 def test_empty_code_block_write_content(


### PR DESCRIPTION
## Summary
- return the result of the evaluator wrapped by `CodeBlockWriterEvaluator`
- retain the existing `finally` write behavior for modifications and exceptions
- verify textual failures reach Sybil and become `SybilFailure`

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1062

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral/API tweak to an evaluator wrapper with preserved write-on-modify semantics; covered by a focused test.
> 
> **Overview**
> **`CodeBlockWriterEvaluator`** now **returns** whatever the inner evaluator returns (`str | None`) instead of always returning nothing, so Sybil can treat a returned string as a test failure.
> 
> The existing **`finally`** path is unchanged: namespace captures still drive disk writes on modification, including when the wrapped evaluator raises.
> 
> A new test confirms a wrapped evaluator that returns a failure message surfaces that text through the wrapper and becomes **`SybilFailure`** on **`example.evaluate()`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3490f1d3095fac5a94cb94b15737310033f11cf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->