### PR TITLE
Write inside empty invisible code blocks

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -79,6 +79,7 @@ def _get_modified_region_text(
     code_block_indent_prefix = first_line[
         : len(first_line) - len(first_line.lstrip())
     ]
+    replacement_search_text = original_region_text
 
     if example.parsed:
         within_code_block_indent_prefix = (
@@ -98,6 +99,12 @@ def _get_modified_region_text(
         within_code_block_indent_prefix = code_block_indent_prefix
         replace_old_not_indented = "\n"
         replace_new_prefix = "\n"
+    elif original_region_text.lstrip().startswith("<!-- invisible-code-block"):
+        # Invisible code block
+        within_code_block_indent_prefix = code_block_indent_prefix
+        replace_old_not_indented = "\n"
+        replace_new_prefix = "\n"
+        replacement_search_text = original_region_text.rstrip("\n")
     else:
         # reStructuredText
         within_code_block_indent_prefix = code_block_indent_prefix + "   "
@@ -116,7 +123,9 @@ def _get_modified_region_text(
     if not replacement_text.endswith("\n"):
         replacement_text += "\n"
 
-    text_to_replace_index = original_region_text.rfind(indented_example_parsed)
+    text_to_replace_index = replacement_search_text.rfind(
+        indented_example_parsed
+    )
     text_before_replacement = original_region_text[:text_to_replace_index]
     text_after_replacement = original_region_text[
         text_to_replace_index + len(indented_example_parsed) :

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -338,6 +338,44 @@ def test_empty_code_block_write_content(
     assert source_file.read_text(encoding="utf-8") == expected_content
 
 
+@pytest.mark.parametrize(
+    argnames="markup_language",
+    argvalues=(MARKDOWN_IT, MYST_PARSER),
+)
+def test_empty_invisible_code_block_write_content(
+    *,
+    tmp_path: Path,
+    markup_language: MarkupLanguage,
+) -> None:
+    """Content is written inside an empty invisible code block."""
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(
+        data="<!-- invisible-code-block python\n-->\n",
+        encoding="utf-8",
+    )
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store modified content in the namespace."""
+        example.document.namespace["modified_content"] = "inserted"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = markup_language.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == (
+        "<!-- invisible-code-block python\ninserted\n-->\n"
+    )
+    reparsed_document = Sybil(parsers=[parser]).parse(path=source_file)
+    (reparsed_example,) = reparsed_document.examples()
+    assert str(object=reparsed_example.parsed) == "inserted\n"
+
+
 def test_empty_code_block_with_options(
     *,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- recognize empty `invisible-code-block` regions in the writer
- select the insertion newline before the HTML comment terminator
- verify MarkdownIt and MystParser output by reparsing the written file

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1063

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to empty-block splice logic in the code block writer, covered by new parser-specific tests.
> 
> **Overview**
> Fixes **write-back for empty invisible code blocks** (`<!-- invisible-code-block … -->`) where the writer could not reliably find the insertion newline before the HTML comment terminator.
> 
> In `_get_modified_region_text`, empty blocks now search only the region **before** `source_offset` (via `search_region_text`) when locating the placeholder newline to replace, so the match targets the gap before `-->` instead of scanning the closing delimiter. Parsed (non-empty) blocks still search the full region text.
> 
> Adds **`test_empty_invisible_code_block_write_content`** for **MarkdownIt** and **MystParser**: writes `inserted` into an empty invisible block, asserts the on-disk markup, and reparses to confirm the example content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bbdbb50918c30d0af37bb1178c22cc279fc1d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->