### PR TITLE
Preserve empty block quote prefixes

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -17,6 +17,17 @@ from sybil.typing import Evaluator
 
 
 @beartype
+def _get_container_prefix(*, region_text: str) -> str:
+    """Get a fenced block's indentation and block quote prefix."""
+    fence_pattern = re.compile(
+        pattern=r"^(?P<prefix>[ \t]*(?:>[ \t]*)*)(?P<fence>`{3,})",
+        flags=re.MULTILINE,
+    )
+    fence_match = fence_pattern.match(string=region_text)
+    return fence_match.group("prefix") if fence_match else ""
+
+
+@beartype
 def _get_within_code_block_indentation_prefix(example: Example) -> str:
     """Get the indentation of the parsed code in the example."""
     first_line = str(object=example.parsed).split(sep="\n", maxsplit=1)[0]
@@ -24,14 +35,9 @@ def _get_within_code_block_indentation_prefix(example: Example) -> str:
         example.region.start : example.region.end
     ]
 
-    # Extract blockquote/container prefix from the region text
-    # This handles Djot/Markdown blockquotes (lines starting with "> ")
-    fence_pattern = re.compile(
-        pattern=r"^(?P<prefix>[ \t]*(?:>[ \t]*)*)(?P<fence>`{3,})",
-        flags=re.MULTILINE,
+    container_prefix = _get_container_prefix(
+        region_text=region_text,
     )
-    fence_match = fence_pattern.match(string=region_text)
-    container_prefix = fence_match.group("prefix") if fence_match else ""
 
     region_lines = region_text.splitlines()
     region_lines_matching_first_line = [
@@ -90,7 +96,9 @@ def _get_modified_region_text(
     # to know about markup language specifics here.
     elif original_region_text.endswith("```"):
         # Markdown or MyST
-        within_code_block_indent_prefix = code_block_indent_prefix
+        within_code_block_indent_prefix = _get_container_prefix(
+            region_text=original_region_text,
+        )
         replace_old_not_indented = "\n"
         replace_new_prefix = "\n"
     elif original_region_text.rstrip().endswith("@end"):

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -338,6 +338,44 @@ def test_empty_code_block_write_content(
     assert source_file.read_text(encoding="utf-8") == expected_content
 
 
+@pytest.mark.parametrize(
+    argnames="markup_language",
+    argvalues=(MARKDOWN_IT, MYST_PARSER, DJOT),
+)
+def test_empty_blockquote_code_block_write_content(
+    *,
+    tmp_path: Path,
+    markup_language: MarkupLanguage,
+) -> None:
+    """Content written to an empty block quote retains its prefix."""
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(
+        data="> ```python\n> ```\n",
+        encoding="utf-8",
+    )
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store modified content in the namespace."""
+        example.document.namespace["modified_content"] = "inserted"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = markup_language.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == (
+        "> ```python\n> inserted\n> ```\n"
+    )
+    reparsed_document = Sybil(parsers=[parser]).parse(path=source_file)
+    (reparsed_example,) = reparsed_document.examples()
+    assert str(object=reparsed_example.parsed) == "inserted\n"
+
+
 def test_empty_code_block_with_options(
     *,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- extract fenced-block container prefixes through a reusable helper
- apply the prefix when writing into empty fenced block quotes
- verify MarkdownIt, MystParser, and Djot output by reparsing it

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1064

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to empty fenced-block write-back in the code block writer, with targeted tests and no auth or data-path impact.
> 
> **Overview**
> Fixes **CodeBlockWriterEvaluator** so inserting content into an **empty fenced code block inside a block quote** keeps each line’s `> ` (and indentation) prefix instead of writing unquoted lines.
> 
> Fence/container prefix detection is moved into **`_get_container_prefix`**, reused for indentation math and for **empty-block** inserts: when a closing fence exists, the writer indents new content with the container prefix (e.g. `> `) rather than only the fence line’s leading whitespace.
> 
> Adds **`test_empty_blockquote_code_block_write_content`** for MarkdownIt, MystParser, and Djot, including a reparse check that the written file still parses as expected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f249abc0a4b622efcdf493b0e804458111d71c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->