### PR TITLE
Recognize spaced empty closing fences

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -88,7 +88,7 @@ def _get_modified_region_text(
         replace_new_prefix = ""
     # This is a break of the abstraction, - we really should not have
     # to know about markup language specifics here.
-    elif original_region_text.endswith("```"):
+    elif original_region_text.rstrip().endswith("```"):
         # Markdown or MyST
         within_code_block_indent_prefix = code_block_indent_prefix
         replace_old_not_indented = "\n"

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -338,6 +338,44 @@ def test_empty_code_block_write_content(
     assert source_file.read_text(encoding="utf-8") == expected_content
 
 
+@pytest.mark.parametrize(
+    argnames="markup_language",
+    argvalues=(MARKDOWN_IT, MYST_PARSER),
+)
+def test_empty_fence_with_trailing_spaces(
+    *,
+    tmp_path: Path,
+    markup_language: MarkupLanguage,
+) -> None:
+    """Trailing spaces do not prevent recognizing an empty fence."""
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(
+        data="```python\n```   \n",
+        encoding="utf-8",
+    )
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store modified content in the namespace."""
+        example.document.namespace["modified_content"] = "inserted"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = markup_language.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == (
+        "```python\ninserted\n```   \n"
+    )
+    reparsed_document = Sybil(parsers=[parser]).parse(path=source_file)
+    (reparsed_example,) = reparsed_document.examples()
+    assert str(object=reparsed_example.parsed) == "inserted\n"
+
+
 def test_empty_code_block_with_options(
     *,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- ignore legal trailing whitespace when identifying an empty backtick fence
- preserve the closing fence’s original trailing spaces during rewriting
- verify MarkdownIt and MystParser output by reparsing it

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1066

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted fence-detection and rewrite behavior for empty blocks; tests lock in MarkdownIt/MystParser round-trips with no auth or data-path changes.
> 
> **Overview**
> **Empty fenced code blocks** whose closing line is only backticks plus trailing spaces (e.g. ` ```   `) are now treated as real fences when writing through `CodeBlockWriterEvaluator`, instead of being mis-handled like blocks without a closing delimiter.
> 
> Writes **keep the closing fence line exactly as authored**, including those trailing spaces, while still inserting the new body. Coverage is extended for **MarkdownIt** and **MystParser** with a round-trip check that the updated file reparses to the inserted content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df419d98570c4f002e784765d6d85b3705627c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->