### PR TITLE
Separate pycon output from input

### DIFF
--- a/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
@@ -221,7 +221,10 @@ def _render_pycon_from_python(
         result.extend(group)
         matched_chunk = chunk_for_group[i]
         if matched_chunk is not None:
-            result.extend(original_chunks[matched_chunk].output_lines)
+            output_lines = original_chunks[matched_chunk].output_lines
+            if output_lines and not result[-1].endswith(("\n", "\r")):
+                result.append("\n")
+            result.extend(output_lines)
 
     return "".join(result)
 

--- a/tests/evaluators/test_pycon_shell_evaluator.py
+++ b/tests/evaluators/test_pycon_shell_evaluator.py
@@ -1,4 +1,4 @@
-"""Tests for pycon source preparer and result transformer."""
+"""Tests for pycon source preparation and result transformation."""
 
 import textwrap
 import uuid
@@ -153,6 +153,46 @@ def test_write_to_file_reformats_pycon(
         ```
         """,
     )
+
+
+def test_preserves_output_after_formatter_removes_final_newline(
+    *,
+    tmp_path: Path,
+) -> None:
+    """Preserved output remains separate from input without a final
+    newline.
+    """
+    content = "```pycon\n>>> 1 + 1\n2\n```\n"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+    script = tmp_path / "fmt.py"
+    script.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import pathlib
+            import sys
+
+            path = pathlib.Path(sys.argv[1])
+            path.write_text(path.read_text().rstrip("\\n"))
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    evaluator = _make_pycon_evaluator(
+        args=["python3", script],
+        write_to_file=True,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="pycon",
+        evaluator=evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=test_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert test_file.read_text(encoding="utf-8") == content
 
 
 def test_no_change_leaves_file_unmodified(


### PR DESCRIPTION
## Summary
- ensure a rendered pycon prompt group ends with a newline before preserved output
- prevent formatter newline policy from merging input and transcript output
- add an end-to-end formatter regression

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1067

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to pycon write-back formatting with a targeted regression test; no auth, I/O, or broader evaluator behavior changes.
> 
> **Overview**
> When pycon blocks are rewritten after shell formatting, **preserved session output** (e.g. `2` after `>>> 1 + 1`) is re-inserted after the matching `>>>` group in `_render_pycon_from_python`. The renderer now **inserts a `\n` before those output lines** when the last rendered prompt line does not already end with a line break.
> 
> That closes a round-trip bug where formatters that **strip trailing newlines** from the extracted Python left the final `>>>` line and the transcript on one line, corrupting the markdown block.
> 
> An end-to-end `write_to_file` test runs a formatter that `rstrip`s newlines and asserts the original pycon fence content is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfd1401171b9fd7eae81e6c08486796adc44abf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->