### PR TITLE
Unpad shell modification callbacks

### DIFF
--- a/src/sybil_extras/evaluators/shell_evaluator/__init__.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/__init__.py
@@ -173,10 +173,15 @@ class _ShellCommandRunner:
             with contextlib.suppress(FileNotFoundError):
                 temp_file.unlink()
 
+        modified_example_content = lstrip_newlines(
+            input_string=temp_file_content,
+            number_of_newlines=padding_line,
+        )
+
         if new_source != temp_file_content and self._on_modify is not None:
             self._on_modify(
                 example=example,
-                modified_example_content=temp_file_content,
+                modified_example_content=modified_example_content,
             )
 
         if self._write_to_file:
@@ -184,12 +189,8 @@ class _ShellCommandRunner:
             # While it is possible that a formatter added leading newlines,
             # we assume that this is not the case, and we remove any leading
             # newlines from the replacement which were added by the padding.
-            new_region_content = lstrip_newlines(
-                input_string=temp_file_content,
-                number_of_newlines=padding_line,
-            )
             new_region_content = self._result_transformer(
-                content=new_region_content,
+                content=modified_example_content,
                 example=example,
             )
             example.document.namespace[self._namespace_key] = (

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -1084,6 +1084,56 @@ def test_custom_on_modify_with_modification(
     example.evaluate()
 
 
+def test_custom_on_modify_receives_unpadded_content(tmp_path: Path) -> None:
+    """The modification callback does not receive line-number padding."""
+    source_file = tmp_path / "example.md"
+    source_file.write_text(
+        data="heading\n\n```python\nx=1\n```\n",
+        encoding="utf-8",
+    )
+    formatter = tmp_path / "formatter.py"
+    formatter.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import pathlib
+            import sys
+
+            path = pathlib.Path(sys.argv[1])
+            path.write_text(path.read_text().replace("x=1", "x = 1"))
+            """
+        ),
+        encoding="utf-8",
+    )
+    modified_contents: list[str] = []
+
+    def on_modify(example: Example, modified_example_content: str) -> None:
+        """Capture the modified example content."""
+        del example
+        modified_contents.append(modified_example_content)
+
+    evaluator = ShellCommandEvaluator(
+        args=[sys.executable, formatter],
+        temp_file_path_maker=make_temp_file_path,
+        pad_file=True,
+        write_to_file=True,
+        use_pty=False,
+        on_modify=on_modify,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="python",
+        evaluator=evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert modified_contents == ["x = 1\n"]
+    reparsed_document = Sybil(parsers=[parser]).parse(path=source_file)
+    (reparsed_example,) = reparsed_document.examples()
+    assert str(object=reparsed_example.parsed) == modified_contents[0]
+
+
 @pytest.mark.parametrize(
     argnames="parser_cls",
     argvalues=(MarkdownItCodeBlockParser, SybilMarkdownCodeBlockParser),


### PR DESCRIPTION
## Summary
- strip only known line-number padding before invoking `on_modify`
- use the same unpadded content for callbacks and write-back transformation
- add an end-to-end padded formatter regression

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1068

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix in the shell evaluator callback and shared unpadded content; write-back was already stripping padding, with regression test coverage.
> 
> **Overview**
> When `pad_file` is enabled, the shell evaluator pads the temp file so tools report correct line numbers. **`on_modify` previously received the full temp file text**, including that padding, which broke callbacks that expect real code block content.
> 
> This PR **strips only the known padding** (via `lstrip_newlines`) into `modified_example_content` once after the command runs, then passes that same string to **`on_modify` and to the write-back / `result_transformer` path**, instead of stripping only during write-back.
> 
> An end-to-end test with `pad_file=True`, a formatter, and `on_modify` asserts the callback sees unpadded content (`x = 1\n`) and matches what gets written back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a770558aaf5283de8787d0fbc8341f248f9e098. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->