### PR TITLE
Reject missing shell result files

### DIFF
--- a/src/sybil_extras/evaluators/shell_evaluator/__init__.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/__init__.py
@@ -155,7 +155,7 @@ class _ShellCommandRunner:
             newline=self._newline,
         )
 
-        temp_file_content = ""
+        temp_file_content = new_source
         try:
             result = run_command(
                 command=[
@@ -165,7 +165,7 @@ class _ShellCommandRunner:
                 use_pty=self._use_pty,
             )
 
-            with contextlib.suppress(FileNotFoundError):
+            if self._write_to_file or self._on_modify is not None:
                 temp_file_content = temp_file.read_text(
                     encoding=self._encoding
                 )

--- a/tests/evaluators/test_shell_evaluator.py
+++ b/tests/evaluators/test_shell_evaluator.py
@@ -728,6 +728,37 @@ def test_non_utf8_output(
     assert output == expected_output
 
 
+def test_deleted_temp_file_does_not_erase_code(tmp_path: Path) -> None:
+    """A deleted formatter result raises and leaves the source
+    unchanged.
+    """
+    original_content = "```python\nimportant = True\n```\n"
+    source_file = tmp_path / "example.md"
+    source_file.write_text(data=original_content, encoding="utf-8")
+    evaluator = ShellCommandEvaluator(
+        args=[
+            sys.executable,
+            "-c",
+            "import pathlib, sys; pathlib.Path(sys.argv[1]).unlink()",
+        ],
+        temp_file_path_maker=make_temp_file_path,
+        pad_file=False,
+        write_to_file=True,
+        use_pty=False,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="python",
+        evaluator=evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    with pytest.raises(expected_exception=FileNotFoundError):
+        example.evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == original_content
+
+
 def test_no_file_left_behind_on_interruption(
     *,
     rst_file: Path,


### PR DESCRIPTION
## Summary
- require the temporary result file when write-back or modification callbacks need it
- raise instead of treating a deleted file as empty formatted content
- retain commands such as `rm` when no result content is consumed

## Testing
- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- repository pre-commit and pre-push hooks

Closes #1069

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes formatter write-back semantics for missing temp files (fail loud vs silent empty read); behavior is intentional and narrowly scoped to shell evaluator temp-file handling.
> 
> **Overview**
> Fixes a bug where **`ShellCommandEvaluator`** could treat a missing temp file as empty formatter output and wipe or corrupt documentation when **`write_to_file`** was enabled.
> 
> **`_ShellCommandRunner`** now seeds **`temp_file_content`** from the written source and only re-reads the temp file when **`write_to_file`** or **`on_modify`** needs the post-command body. A deleted or missing result file surfaces **`FileNotFoundError`** instead of being swallowed. Commands that only run side effects (e.g. **`rm`**) without consuming file content are unchanged because they no longer read the temp path unless write-back or modify callbacks are configured.
> 
> Adds **`test_deleted_temp_file_does_not_erase_code`** to assert evaluation fails and the markdown source stays intact when the shell command deletes the temp file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6d9084ead84056145fbd6eb4e7658b9b1cce2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->