### PR TITLE
Release abandoned grouping documents

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -1,11 +1,41 @@
 """Shared utilities for grouping parsers."""
 
 from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
 
 from beartype import beartype
-from sybil import Example, Region
+from sybil import Document, Example, Region
 from sybil.region import Lexeme
 from sybil.typing import Evaluator
+
+
+@beartype
+@dataclass(frozen=True, kw_only=True)
+class CollectedExample:
+    """An example snapshot that does not retain its document."""
+
+    line: int
+    column: int
+    region: Region
+
+    @classmethod
+    def from_example(cls, *, example: Example) -> "CollectedExample":
+        """Create a document-free snapshot of an example."""
+        return cls(
+            line=example.line,
+            column=example.column,
+            region=example.region,
+        )
+
+    def restore(self, *, document: Document) -> Example:
+        """Restore the example for a live document."""
+        return Example(
+            document=document,
+            line=self.line,
+            column=self.column,
+            region=self.region,
+            namespace=document.namespace,
+        )
 
 
 @beartype

--- a/src/sybil_extras/parsers/abstract/group_all.py
+++ b/src/sybil_extras/parsers/abstract/group_all.py
@@ -9,6 +9,7 @@ collected before combining them.
 
 import threading
 from collections.abc import Iterable
+from weakref import WeakKeyDictionary
 
 from beartype import beartype
 from sybil import Document, Example, Region
@@ -16,6 +17,7 @@ from sybil.example import NotEvaluated
 from sybil.typing import Evaluator
 
 from ._grouping_utils import (
+    CollectedExample,
     count_expected_code_blocks,
     create_combined_example,
     create_combined_region,
@@ -30,7 +32,7 @@ class _GroupAllState:
     def __init__(self, *, expected_code_blocks: int) -> None:
         """Initialize the group all state."""
         self.expected_code_blocks = expected_code_blocks
-        self.examples: list[Example] = []
+        self.examples: list[CollectedExample] = []
         self.lock = threading.Lock()
         self.ready = threading.Condition(lock=self.lock)
         self.collected_count = 0
@@ -57,7 +59,9 @@ class _GroupAllEvaluator:
         file
                 to not have a bunch of newlines in it, such as formatters.
         """
-        self._document_state: dict[Document, _GroupAllState] = {}
+        self._document_state: WeakKeyDictionary[Document, _GroupAllState] = (
+            WeakKeyDictionary()
+        )
         self._evaluator = evaluator
         self._pad_groups = pad_groups
 
@@ -81,7 +85,9 @@ class _GroupAllEvaluator:
 
         with state.ready:
             if has_source(example=example):
-                state.examples.append(example)
+                state.examples.append(
+                    CollectedExample.from_example(example=example)
+                )
                 state.collected_count += 1
                 state.ready.notify_all()
                 return
@@ -105,10 +111,14 @@ class _GroupAllEvaluator:
 
             # Sort examples by their position in the document to ensure
             # correct order regardless of evaluation order (thread-safety)
-            sorted_examples = sorted(
+            sorted_collected_examples = sorted(
                 state.examples,
-                key=lambda ex: ex.region.start,
+                key=lambda collected: collected.region.start,
             )
+            sorted_examples = [
+                collected.restore(document=example.document)
+                for collected in sorted_collected_examples
+            ]
             try:
                 region = create_combined_region(
                     examples=sorted_examples,

--- a/src/sybil_extras/parsers/abstract/grouped_source.py
+++ b/src/sybil_extras/parsers/abstract/grouped_source.py
@@ -11,6 +11,7 @@ import threading
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import Literal
+from weakref import WeakKeyDictionary
 
 from beartype import beartype
 from sybil import Document, Example, Region
@@ -19,20 +20,12 @@ from sybil.parsers.abstract.lexers import LexerCollection
 from sybil.typing import Evaluator, Lexer
 
 from ._grouping_utils import (
+    CollectedExample,
     count_expected_code_blocks,
     create_combined_example,
     create_combined_region,
     has_source,
 )
-
-
-@beartype
-@dataclass(frozen=True, kw_only=True)
-class _GroupStateKey:
-    """Key for looking up group state."""
-
-    document: Document
-    group_id: int
 
 
 @beartype
@@ -74,7 +67,7 @@ class _GroupState:
         self.start_position = start_position
         self.end_position = end_position
         self.expected_code_blocks = expected_code_blocks
-        self.examples: list[Example] = []
+        self.examples: list[CollectedExample] = []
         self.lock = threading.Lock()
         self.ready = threading.Condition(lock=self.lock)
         self.collected_count = 0
@@ -103,15 +96,19 @@ class _Grouper:
         file
                 to not have a bunch of newlines in it, such as formatters.
         """
-        # State is keyed by _GroupStateKey to allow multiple groups
-        # in the same document to be processed in parallel.
-        self._group_state: dict[_GroupStateKey, _GroupState] = {}
+        # Nested state allows multiple groups in the same document while
+        # retaining the document only as a weak key.
+        self._group_state: WeakKeyDictionary[
+            Document, dict[int, _GroupState]
+        ] = WeakKeyDictionary()
         self._group_state_lock = threading.Lock()
         self._evaluator = evaluator
         self._directive = directive
         self._pad_groups = pad_groups
         # Track group boundaries per document for determining membership
-        self._group_boundaries: dict[Document, list[_GroupBoundary]] = {}
+        self._group_boundaries: WeakKeyDictionary[
+            Document, list[_GroupBoundary]
+        ] = WeakKeyDictionary()
         self._group_boundaries_lock = threading.Lock()
 
     def register_group(
@@ -141,8 +138,9 @@ class _Grouper:
                     end_position=end_position,
                 )
             )
-            key = _GroupStateKey(document=document, group_id=group_id)
-            self._group_state[key] = _GroupState(
+            if document not in self._group_state:
+                self._group_state[document] = {}
+            self._group_state[document][group_id] = _GroupState(
                 start_position=start_position,
                 end_position=end_position,
                 expected_code_blocks=expected_code_blocks,
@@ -163,14 +161,13 @@ class _Grouper:
         boundary and retrieving the state.
         """
         with self._group_boundaries_lock, self._group_state_lock:
-            boundaries = self._group_boundaries.get(document, [])
+            boundaries = self._group_boundaries.get(
+                key=document,
+                default=list[_GroupBoundary](),
+            )
             for boundary in boundaries:
                 if boundary.start_position < position < boundary.end_position:
-                    key = _GroupStateKey(
-                        document=document,
-                        group_id=boundary.group_id,
-                    )
-                    return self._group_state[key]
+                    return self._group_state[document][boundary.group_id]
         return None
 
     def _get_group_state(
@@ -180,9 +177,8 @@ class _Grouper:
         group_id: int,
     ) -> _GroupState:
         """Get the state for a specific group."""
-        key = _GroupStateKey(document=document, group_id=group_id)
         with self._group_state_lock:
-            return self._group_state[key]
+            return self._group_state[document][group_id]
 
     def _cleanup_group_state(
         self,
@@ -198,10 +194,9 @@ class _Grouper:
         multiple threads could both see an empty boundary list and call
         pop_evaluator.
         """
-        key = _GroupStateKey(document=document, group_id=group_id)
         # Hold both locks to ensure atomic cleanup and pop_evaluator call
         with self._group_boundaries_lock, self._group_state_lock:
-            del self._group_state[key]
+            del self._group_state[document][group_id]
             self._group_boundaries[document] = [
                 boundary
                 for boundary in self._group_boundaries[document]
@@ -209,6 +204,7 @@ class _Grouper:
             ]
             if not self._group_boundaries[document]:
                 del self._group_boundaries[document]
+                del self._group_state[document]
                 document.pop_evaluator(evaluator=self)
 
     def _evaluate_grouper_example(self, example: Example) -> None:
@@ -232,10 +228,14 @@ class _Grouper:
                     # Sort examples by their position in the document to ensure
                     # correct order regardless of evaluation order
                     # (for thread-safety).
-                    sorted_examples = sorted(
+                    sorted_collected_examples = sorted(
                         state.examples,
-                        key=lambda ex: ex.region.start,
+                        key=lambda collected: collected.region.start,
                     )
+                    sorted_examples = [
+                        collected.restore(document=example.document)
+                        for collected in sorted_collected_examples
+                    ]
                     region = create_combined_region(
                         examples=sorted_examples,
                         evaluator=self._evaluator,
@@ -268,7 +268,9 @@ class _Grouper:
 
         with state.ready:
             if has_source(example=example):
-                state.examples.append(example)
+                state.examples.append(
+                    CollectedExample.from_example(example=example)
+                )
                 state.collected_count += 1
                 state.ready.notify_all()
                 return

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -1,7 +1,9 @@
 """Group-all parser tests shared across markup languages."""
 
+import gc
 import subprocess
 import uuid
+import weakref
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -18,6 +20,44 @@ from sybil_extras.languages import (
     DirectiveBuilder,
     MarkupLanguage,
 )
+
+
+def test_abandoned_documents_are_released(
+    *,
+    language: MarkupLanguage,
+    tmp_path: Path,
+) -> None:
+    """Parsed documents are released when their finalizers never run."""
+    evaluator = NoOpEvaluator()
+    group_all_parser = language.group_all_parser_cls(
+        evaluator=evaluator,
+        pad_groups=False,
+    )
+    code_block_parser = language.code_block_parser_cls(
+        language="python",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[code_block_parser, group_all_parser])
+    references: list[weakref.ReferenceType[Document]] = []
+
+    def parse_reference(*, path: Path) -> weakref.ReferenceType[Document]:
+        """Parse a document without preserving a local strong
+        reference.
+        """
+        document = sybil.parse(path=path)
+        return weakref.ref(document)
+
+    for index in range(3):
+        test_document = tmp_path / f"test-{index}"
+        test_document.write_text(
+            data=language.code_block_builder(code="pass", language="python"),
+            encoding="utf-8",
+        )
+        references.append(parse_reference(path=test_document))
+
+    gc.collect()
+
+    assert all(reference() is None for reference in references)
 
 
 @beartype

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -27,7 +27,7 @@ def test_abandoned_documents_are_released(
     language: MarkupLanguage,
     tmp_path: Path,
 ) -> None:
-    """Parsed documents are released when their finalizers never run."""
+    """Parsed documents are released when their end markers never run."""
     evaluator = NoOpEvaluator()
     group_all_parser = language.group_all_parser_cls(
         evaluator=evaluator,

--- a/tests/parsers/test_grouped_source.py
+++ b/tests/parsers/test_grouped_source.py
@@ -1,18 +1,67 @@
 """Grouped source parser tests shared across markup languages."""
 
+import gc
 import subprocess
 import uuid
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 from beartype import beartype
-from sybil import Example, Sybil
+from sybil import Document, Example, Sybil
 
 from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
 from sybil_extras.evaluators.no_op import NoOpEvaluator
 from sybil_extras.evaluators.shell_evaluator import ShellCommandEvaluator
 from sybil_extras.languages import DirectiveBuilder, MarkupLanguage
+
+
+def test_abandoned_documents_are_released(
+    *,
+    language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
+    tmp_path: Path,
+) -> None:
+    """Parsed documents are released when their finalizers never run."""
+    language, directive_builder = language_directive_builder
+    evaluator = NoOpEvaluator()
+    group_parser = language.group_parser_cls(
+        directive="group",
+        evaluator=evaluator,
+        pad_groups=False,
+    )
+    code_block_parser = language.code_block_parser_cls(
+        language="python",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[code_block_parser, group_parser])
+    references: list[weakref.ReferenceType[Document]] = []
+    content = language.markup_separator.join(
+        [
+            directive_builder(directive="group", argument="start"),
+            language.code_block_builder(code="pass", language="python"),
+            directive_builder(directive="group", argument="end"),
+        ]
+    )
+
+    def parse_reference(*, path: Path) -> weakref.ReferenceType[Document]:
+        """Parse a document without preserving a local strong
+        reference.
+        """
+        document = sybil.parse(path=path)
+        return weakref.ref(document)
+
+    for index in range(3):
+        test_document = tmp_path / f"test-{index}"
+        test_document.write_text(
+            data=f"{content}{language.markup_separator}",
+            encoding="utf-8",
+        )
+        references.append(parse_reference(path=test_document))
+
+    gc.collect()
+
+    assert all(reference() is None for reference in references)
 
 
 @beartype

--- a/tests/parsers/test_grouped_source.py
+++ b/tests/parsers/test_grouped_source.py
@@ -22,7 +22,7 @@ def test_abandoned_documents_are_released(
     language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
     tmp_path: Path,
 ) -> None:
-    """Parsed documents are released when their finalizers never run."""
+    """Parsed documents are released when their end markers never run."""
     language, directive_builder = language_directive_builder
     evaluator = NoOpEvaluator()
     group_parser = language.group_parser_cls(


### PR DESCRIPTION
## Summary

- store grouping state in weak-key dictionaries keyed by document
- snapshot collected examples without retaining their documents
- reconstruct examples only while a live finalizer evaluates
- add lifecycle regressions for group-all and grouped-source parsers

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (906 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- repository commit hooks

Closes #1070

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent grouping/finalization paths and example reconstruction at finalize time; behavior should be unchanged when evaluation completes, but threading and lifecycle edge cases warrant careful review.
> 
> **Overview**
> Fixes a **memory leak** when parsed documents are dropped before group **end/finalize** markers run (for example parse-only workflows or partial evaluation). Grouping parsers no longer keep those `Document` instances alive indefinitely.
> 
> **Group-all** and **grouped-source** evaluators now index per-document state in `WeakKeyDictionary` instead of strong `dict` keys. Collected blocks are stored as `CollectedExample` snapshots (line, column, region only) via `CollectedExample.from_example`, and full `Example` objects are rebuilt with `restore(document=...)` only when the live finalizer runs. Grouped-source drops `_GroupStateKey` in favor of nested weak-key maps and removes the document entry when the last group cleans up.
> 
> Adds **`test_abandoned_documents_are_released`** for both parsers: parse several files, hold only weakrefs, `gc.collect()`, assert documents are collectable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 816b3524bed71ea55a844c75abc6a05f2b1d508f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->