### PR TITLE
Ignore non-code MyST directives

### DIFF
--- a/src/sybil_extras/parsers/myst_parser/codeblock.py
+++ b/src/sybil_extras/parsers/myst_parser/codeblock.py
@@ -27,6 +27,7 @@ _INVISIBLE_CODE_BLOCK_PATTERN = re.compile(
     r"(?:\n|(?=--+>))",
 )
 _HTML_COMMENT_END_PATTERN = re.compile(pattern=r"--+>")
+_CODE_DIRECTIVES = frozenset({"{code}", "{code-block}", "{code-cell}"})
 
 
 @beartype
@@ -112,8 +113,10 @@ class CodeBlockParser:
         words = token.info.strip().split()
         if not words:
             block_language = ""
-        elif words[0].startswith("{"):
+        elif words[0] in _CODE_DIRECTIVES:
             block_language = words[1] if len(words) > 1 else ""
+        elif words[0].startswith("{"):
+            return None
         else:
             block_language = words[0]
 

--- a/tests/parsers/myst_parser/test_codeblock.py
+++ b/tests/parsers/myst_parser/test_codeblock.py
@@ -285,6 +285,34 @@ def test_myst_directive_code_block(*, tmp_path: Path, directive: str) -> None:
     assert examples[0].region.lexemes["language"] == "python"
 
 
+@pytest.mark.parametrize(argnames="language", argvalues=(None, "python"))
+@pytest.mark.parametrize(
+    argnames="directive",
+    argvalues=("note", "warning", "admonition"),
+)
+def test_non_code_myst_directive_is_skipped(
+    *,
+    tmp_path: Path,
+    directive: str,
+    language: str | None,
+) -> None:
+    """MyST directives that contain prose are not code blocks."""
+    content = textwrap.dedent(
+        text=f"""\
+        ```{{{directive}}} python
+        This is prose, not Python.
+        ```
+        """,
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    parser = CodeBlockParser(language=language, evaluator=NoOpEvaluator())
+    document = Sybil(parsers=[parser]).parse(path=test_file)
+
+    assert not list(document.examples())
+
+
 @pytest.mark.parametrize(
     argnames="directive",
     argvalues=("code-block", "code", "code-cell"),


### PR DESCRIPTION
## Summary

- recognize language arguments only on MyST code-bearing directives
- skip prose directives such as `note`, `warning`, and `admonition`
- preserve `{code}`, `{code-block}`, and `{code-cell}` behavior
- cover filtered and unfiltered parser configurations

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (893 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1071

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to fence info-string handling in the MyST parser with added regression tests; no auth, data, or security-sensitive paths.
> 
> **Overview**
> **MyST `CodeBlockParser` no longer treats prose directive fences as executable examples.** Fences whose info string starts with a `{...}` directive are only parsed as code when the directive is `{code}`, `{code-block}`, or `{code-cell}`; other directives (e.g. `note`, `warning`, `admonition`) are skipped even if a second token looks like a language.
> 
> Language extraction for the allowed code directives is unchanged (second word of the info string). Tests cover skipped prose directives with and without a `language` filter on the parser.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e88138479cefd4cf69eafa6fe9c9fb050a132a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->