### PR TITLE
Serialize block accumulation

### DIFF
--- a/src/sybil_extras/evaluators/block_accumulator.py
+++ b/src/sybil_extras/evaluators/block_accumulator.py
@@ -1,5 +1,7 @@
 """Block accumulator evaluator."""
 
+import threading
+
 from beartype import beartype
 from sybil.example import Example
 
@@ -24,6 +26,7 @@ class BlockAccumulatorEvaluator:
                 storing accumulated blocks.
         """
         self._namespace_key = namespace_key
+        self._lock = threading.Lock()
 
     def __call__(self, example: Example) -> None:
         """Add the parsed code block content to the namespace.
@@ -31,11 +34,12 @@ class BlockAccumulatorEvaluator:
         Args:
             example: The example to evaluate.
         """
-        existing_blocks = example.document.namespace.get(
-            self._namespace_key,
-            [],
-        )
-        example.document.namespace[self._namespace_key] = [
-            *existing_blocks,
-            example.parsed,
-        ]
+        with self._lock:
+            existing_blocks = example.document.namespace.get(
+                self._namespace_key,
+                [],
+            )
+            example.document.namespace[self._namespace_key] = [
+                *existing_blocks,
+                example.parsed,
+            ]

--- a/tests/evaluators/test_block_accumulator.py
+++ b/tests/evaluators/test_block_accumulator.py
@@ -1,11 +1,75 @@
 """Tests for the BlockAccumulatorEvaluator."""
 
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from sybil import Sybil
+from sybil import Example, Sybil
 from sybil.parsers.rest.codeblock import CodeBlockParser
 
 from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
+
+
+class _ConcurrencyCheckingNamespace(dict[str, object]):
+    """A namespace that rejects overlapping reads."""
+
+    def __init__(self) -> None:
+        """Initialize the namespace."""
+        super().__init__()
+        self._active = False
+        self._lock = threading.Lock()
+
+    def get(self, key: object, default: object = None) -> object:
+        """Get a value while checking that access is serialized."""
+        with self._lock:
+            if self._active:  # pragma: no cover
+                msg = "concurrent namespace access"
+                raise RuntimeError(msg)
+            self._active = True
+        try:
+            time.sleep(0.05)
+            if not isinstance(key, str):  # pragma: no cover
+                return default
+            return super().get(key, default)
+        finally:
+            with self._lock:
+                self._active = False
+
+
+def test_concurrent_evaluation_retains_all_blocks(tmp_path: Path) -> None:
+    """Concurrent evaluations serialize namespace updates."""
+    content = """\
+.. code-block:: python
+
+   first
+
+.. code-block:: python
+
+   second
+"""
+    test_document = tmp_path / "test.rst"
+    test_document.write_text(data=content, encoding="utf-8")
+    evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
+    parser = CodeBlockParser(language="python", evaluator=evaluator)
+    document = Sybil(parsers=[parser]).parse(path=test_document)
+    document.namespace = _ConcurrencyCheckingNamespace()
+    examples = list(document.examples())
+    start = threading.Barrier(parties=2)
+
+    def evaluate(example: Example) -> None:
+        """Evaluate an example after both workers are ready."""
+        start.wait()
+        example.evaluate()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        list(executor.map(evaluate, examples))
+
+    blocks_object: object = document.namespace["blocks"]
+    assert blocks_object in (
+        ["first\n", "second"],
+        ["second", "first\n"],
+    )
 
 
 def test_accumulates_blocks(tmp_path: Path) -> None:

--- a/tests/evaluators/test_block_accumulator.py
+++ b/tests/evaluators/test_block_accumulator.py
@@ -11,30 +11,30 @@ from sybil.parsers.rest.codeblock import CodeBlockParser
 from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
 
 
-class _ConcurrencyCheckingNamespace(dict[str, object]):
-    """A namespace that rejects overlapping reads."""
+class _ConcurrencyTrackingNamespace(dict[str, object]):
+    """A namespace that records the peak overlap of concurrent reads."""
 
     def __init__(self) -> None:
         """Initialize the namespace."""
         super().__init__()
-        self._active = False
+        self._active = 0
+        self.max_concurrent = 0
         self._lock = threading.Lock()
 
     def get(self, key: object, default: object = None) -> object:
-        """Get a value while checking that access is serialized."""
+        """Get a value while recording how many reads overlap."""
         with self._lock:
-            if self._active:  # pragma: no cover
-                msg = "concurrent namespace access"
-                raise RuntimeError(msg)
-            self._active = True
+            self._active += 1
+            self.max_concurrent = max(self.max_concurrent, self._active)
         try:
             time.sleep(0.05)
-            if not isinstance(key, str):  # pragma: no cover
-                return default
+            # ``key`` is typed ``object`` to match ``dict.get`` across type
+            # checkers; the namespace is only ever queried with string keys.
+            assert isinstance(key, str)
             return super().get(key, default)
         finally:
             with self._lock:
-                self._active = False
+                self._active -= 1
 
 
 def test_concurrent_evaluation_retains_all_blocks(tmp_path: Path) -> None:
@@ -53,7 +53,8 @@ def test_concurrent_evaluation_retains_all_blocks(tmp_path: Path) -> None:
     evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
     parser = CodeBlockParser(language="python", evaluator=evaluator)
     document = Sybil(parsers=[parser]).parse(path=test_document)
-    document.namespace = _ConcurrencyCheckingNamespace()
+    namespace = _ConcurrencyTrackingNamespace()
+    document.namespace = namespace
     examples = list(document.examples())
     start = threading.Barrier(parties=2)
 
@@ -65,6 +66,7 @@ def test_concurrent_evaluation_retains_all_blocks(tmp_path: Path) -> None:
     with ThreadPoolExecutor(max_workers=2) as executor:
         list(executor.map(evaluate, examples))
 
+    assert namespace.max_concurrent == 1
     blocks_object: object = document.namespace["blocks"]
     assert blocks_object in (
         ["first\n", "second"],


### PR DESCRIPTION
## Summary

- serialize each accumulator’s namespace read-and-write transaction
- prevent concurrent examples from overwriting one another’s blocks
- add a coordinated two-worker regression that detects overlapping namespace access
- accept either legitimate worker ordering while requiring both blocks

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (888 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1072

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to a test-helper evaluator with added thread-safety; no auth, I/O, or production API surface.
> 
> **Overview**
> **`BlockAccumulatorEvaluator`** now wraps its namespace read-and-append in a **`threading.Lock`**, so parallel example evaluation cannot interleave get/list updates and drop blocks.
> 
> A new regression test runs two workers against a document with two code blocks, uses a barrier to start them together, and asserts namespace reads do not overlap (`max_concurrent == 1`) while both parsed blocks still end up in the accumulated list (order may vary).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4955df3dae60ff5fae7e4ab85fb2cae3dea67a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->