### PR TITLE
Drop stale pycon output

### DIFF
--- a/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
@@ -65,6 +65,7 @@ def pycon_to_python(*, pycon_text: str) -> str:
 class _PyconChunk:
     """A parsed pycon interaction chunk."""
 
+    python_text: str
     output_lines: list[str]
 
 
@@ -89,6 +90,7 @@ class _PyconTranscript:
             A parsed transcript.
         """
         chunks: list[_PyconChunk] = []
+        current_input: list[str] = []
         current_output: list[str] = []
         seen_prompt = False
 
@@ -96,15 +98,31 @@ class _PyconTranscript:
             stripped = line.rstrip("\n\r")
             if stripped == ">>>" or line.startswith(">>> "):
                 if seen_prompt:
-                    chunks.append(_PyconChunk(output_lines=current_output))
+                    chunks.append(
+                        _PyconChunk(
+                            python_text="".join(current_input),
+                            output_lines=current_output,
+                        )
+                    )
+                    current_input = []
                     current_output = []
                 seen_prompt = True
+                current_input.append(
+                    line[4:] if line.startswith(">>> ") else line[3:]
+                )
             elif stripped == "..." or line.startswith("... "):
-                pass
+                current_input.append(
+                    line[4:] if line.startswith("... ") else line[3:]
+                )
             else:
                 current_output.append(line)
 
-        chunks.append(_PyconChunk(output_lines=current_output))
+        chunks.append(
+            _PyconChunk(
+                python_text="".join(current_input),
+                output_lines=current_output,
+            )
+        )
 
         return cls(chunks=chunks)
 
@@ -170,6 +188,22 @@ def _is_separator_group(*, group: list[str]) -> bool:
 
 
 @beartype
+def _statements_are_equivalent(
+    *,
+    group: list[str],
+    chunk: _PyconChunk,
+) -> bool:
+    """Return whether a rendered group matches its original statement."""
+    group_python = pycon_to_python(pycon_text="".join(group))
+    try:
+        group_tree = ast.parse(source=group_python)
+        chunk_tree = ast.parse(source=chunk.python_text)
+    except SyntaxError:
+        return group_python == chunk.python_text
+    return ast.dump(node=group_tree) == ast.dump(node=chunk_tree)
+
+
+@beartype
 def _render_pycon_from_python(
     *,
     python_text: str,
@@ -220,7 +254,10 @@ def _render_pycon_from_python(
     for i, group in enumerate(iterable=groups):
         result.extend(group)
         matched_chunk = chunk_for_group[i]
-        if matched_chunk is not None:
+        if matched_chunk is not None and _statements_are_equivalent(
+            group=group,
+            chunk=original_chunks[matched_chunk],
+        ):
             result.extend(original_chunks[matched_chunk].output_lines)
 
     return "".join(result)
@@ -233,8 +270,8 @@ def python_to_pycon(*, python_text: str, original_pycon: str) -> str:
     Adds ``>>> `` to the first line of each top-level statement and ``... ``
     to continuation lines.  Lines not belonging to any AST statement (such
     as comments or blank lines) also receive ``>>> ``.  Output lines from
-    the original pycon content are preserved when the number of ``>>>``
-    groups matches the number of original pycon chunks.
+    the original pycon content are preserved when the corresponding
+    statement remains equivalent.
 
     Args:
         python_text: Formatted Python source code (no prompts).

--- a/tests/evaluators/test_pycon_shell_evaluator.py
+++ b/tests/evaluators/test_pycon_shell_evaluator.py
@@ -13,7 +13,6 @@ from sybil.parsers.markdown import (
 )
 
 from sybil_extras.evaluators.shell_evaluator import ShellCommandEvaluator
-from sybil_extras.evaluators.shell_evaluator._pycon import python_to_pycon
 from sybil_extras.evaluators.shell_evaluator.exceptions import (
     InvalidPyconError,
 )
@@ -29,28 +28,6 @@ from sybil_extras.evaluators.shell_evaluator.source_preparer import (
 def make_temp_file_path(*, example: Example) -> Path:
     """Create a temporary file path for an example code block."""
     return Path(example.path).parent / f"temp_{uuid.uuid4().hex[:8]}.py"
-
-
-def test_changed_statement_drops_stale_output() -> None:
-    """Output is dropped when its statement changes meaning."""
-    original = ">>> 1 + 1\n2\n>>> 2 + 2\n4\n"
-
-    result = python_to_pycon(
-        python_text="1 + 2\n2 + 2\n",
-        original_pycon=original,
-    )
-
-    assert result == ">>> 1 + 2\n>>> 2 + 2\n4\n"
-
-
-def test_invalid_original_statement_drops_stale_output() -> None:
-    """Output is dropped when the original statement cannot be parsed."""
-    result = python_to_pycon(
-        python_text="pass\n",
-        original_pycon=">>> def (\nSyntaxError\n",
-    )
-
-    assert result == ">>> pass\n"
 
 
 @beartype
@@ -173,6 +150,113 @@ def test_write_to_file_reformats_pycon(
         >>> x = 1 + 1
         >>> x
         2
+        ```
+        """,
+    )
+
+
+def test_changed_statement_drops_stale_output(
+    *,
+    tmp_path: Path,
+) -> None:
+    """Output is dropped when its statement changes meaning."""
+    content = textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> 1 + 1
+        2
+        >>> 2 + 2
+        4
+        ```
+        """,
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    script = tmp_path / "fmt.py"
+    script.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import pathlib
+            import sys
+
+            path = pathlib.Path(sys.argv[1])
+            path.write_text(path.read_text().replace("1 + 1", "1 + 2"))
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    evaluator = _make_pycon_evaluator(
+        args=["python3", str(object=script)],
+        write_to_file=True,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="pycon",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    (example,) = document.examples()
+    example.evaluate()
+
+    assert test_file.read_text(encoding="utf-8") == textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> 1 + 2
+        >>> 2 + 2
+        4
+        ```
+        """,
+    )
+
+
+def test_invalid_original_statement_drops_stale_output(
+    *,
+    tmp_path: Path,
+) -> None:
+    """Output is dropped when the original statement cannot be parsed."""
+    content = textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> def (
+        SyntaxError
+        ```
+        """,
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    script = tmp_path / "fmt.py"
+    script.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import pathlib
+            import sys
+
+            pathlib.Path(sys.argv[1]).write_text("pass\\n")
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    evaluator = _make_pycon_evaluator(
+        args=["python3", str(object=script)],
+        write_to_file=True,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="pycon",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    (example,) = document.examples()
+    example.evaluate()
+
+    assert test_file.read_text(encoding="utf-8") == textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> pass
         ```
         """,
     )

--- a/tests/evaluators/test_pycon_shell_evaluator.py
+++ b/tests/evaluators/test_pycon_shell_evaluator.py
@@ -1,4 +1,4 @@
-"""Tests for pycon source preparer and result transformer."""
+"""Tests for pycon source preparation and result transformation."""
 
 import textwrap
 import uuid
@@ -13,6 +13,7 @@ from sybil.parsers.markdown import (
 )
 
 from sybil_extras.evaluators.shell_evaluator import ShellCommandEvaluator
+from sybil_extras.evaluators.shell_evaluator._pycon import python_to_pycon
 from sybil_extras.evaluators.shell_evaluator.exceptions import (
     InvalidPyconError,
 )
@@ -28,6 +29,28 @@ from sybil_extras.evaluators.shell_evaluator.source_preparer import (
 def make_temp_file_path(*, example: Example) -> Path:
     """Create a temporary file path for an example code block."""
     return Path(example.path).parent / f"temp_{uuid.uuid4().hex[:8]}.py"
+
+
+def test_changed_statement_drops_stale_output() -> None:
+    """Output is dropped when its statement changes meaning."""
+    original = ">>> 1 + 1\n2\n>>> 2 + 2\n4\n"
+
+    result = python_to_pycon(
+        python_text="1 + 2\n2 + 2\n",
+        original_pycon=original,
+    )
+
+    assert result == ">>> 1 + 2\n>>> 2 + 2\n4\n"
+
+
+def test_invalid_original_statement_drops_stale_output() -> None:
+    """Output is dropped when the original statement cannot be parsed."""
+    result = python_to_pycon(
+        python_text="pass\n",
+        original_pycon=">>> def (\nSyntaxError\n",
+    )
+
+    assert result == ">>> pass\n"
 
 
 @beartype


### PR DESCRIPTION
## Summary

- retain each original pycon chunk’s Python input alongside its output
- compare transformed and original statements by AST before restoring output
- drop stale output only for statements that changed, preserving unaffected neighbors
- handle unparseable original statements conservatively

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (889 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1073

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to doctest/pycon formatting in the shell evaluator; behavior is stricter and better documented, with new regression tests and no auth or data-path impact.
> 
> **Overview**
> **Pycon write-back** no longer blindly reattaches interactive output from the original transcript. Each parsed chunk now keeps the **input Python** for that `>>>` block, and output is restored only when the reformatted statement is **AST-equivalent** to that original input (with a text fallback when parsing fails).
> 
> If a formatter changes what a statement means—e.g. `1 + 1` → `1 + 2`—the old `2` line is dropped while **unchanged** neighbors still keep their output. Unparseable original input is handled conservatively: stale output is not carried over when equivalence cannot be established.
> 
> Integration tests cover changed statements and invalid originals through the full Sybil shell evaluator `write_to_file` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1cb9ef75977e35c4f6bf371895802e3024ec445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->