### PR TITLE
Parse MyST jinja context arguments

### DIFF
--- a/src/sybil_extras/parsers/myst_parser/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/myst_parser/sphinx_jinja2.py
@@ -15,6 +15,9 @@ from sybil.typing import Evaluator
 from sybil_extras.parsers._line_offsets import line_offsets
 
 _OPTION_PATTERN = re.compile(pattern=r"^:(?P<key>\w+):\s*(?P<value>.*)$")
+_JINJA_INFO_PATTERN = re.compile(
+    pattern=r"^\{jinja\}(?:\s+(?P<arguments>.*))?$"
+)
 
 
 @beartype
@@ -75,9 +78,13 @@ class SphinxJinja2Parser:
             if token.type != "fence":
                 continue
 
-            # Only match {jinja} directives
-            if token.info.strip() != "{jinja}":
+            # Only match {jinja} directives, with an optional argument.
+            info_match = _JINJA_INFO_PATTERN.fullmatch(
+                string=token.info.strip()
+            )
+            if info_match is None:
                 continue
+            arguments = info_match.group("arguments") or ""
 
             if token.map is None:  # pragma: no cover
                 # This should never happen; map is always set for fence tokens.
@@ -98,7 +105,7 @@ class SphinxJinja2Parser:
 
             lexemes: dict[str, str | dict[str, str]] = {
                 "directive": "jinja",
-                "arguments": "",
+                "arguments": arguments,
                 "source": body,
                 "options": options,
             }

--- a/tests/parsers/test_sphinx_jinja2.py
+++ b/tests/parsers/test_sphinx_jinja2.py
@@ -25,6 +25,36 @@ from sybil_extras.parsers.rest.sphinx_jinja2 import (
         pytest.param(MystParserSphinxJinja2Parser, id="myst-parser"),
     ),
 )
+def test_sphinx_jinja2_named_context(
+    *,
+    parser_cls: type,
+    tmp_path: Path,
+) -> None:
+    """MyST jinja directives expose their named context argument."""
+    content = textwrap.dedent(
+        text="""\
+        ```{jinja} ctx1
+        Hello {{ name }}!
+        ```
+        """,
+    )
+    test_document = tmp_path / "test.md"
+    test_document.write_text(data=content, encoding="utf-8")
+    parser = parser_cls(evaluator=NoOpEvaluator())
+
+    (example,) = Sybil(parsers=[parser]).parse(path=test_document).examples()
+
+    assert example.parsed == "Hello {{ name }}!\n"
+    assert example.region.lexemes["arguments"] == "ctx1"
+
+
+@pytest.mark.parametrize(
+    argnames="parser_cls",
+    argvalues=(
+        pytest.param(MystSphinxJinja2Parser, id="myst"),
+        pytest.param(MystParserSphinxJinja2Parser, id="myst-parser"),
+    ),
+)
 def test_sphinx_jinja2(
     *,
     parser_cls: type,


### PR DESCRIPTION
## Summary

- accept an optional argument after the exact `{jinja}` directive name
- expose named contexts through the `arguments` lexeme
- retain argument-free directive behavior
- add parity coverage for both MyST parser implementations

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (889 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1074

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized parser matching change with backward-compatible behavior for directives without arguments; no auth, data, or infrastructure impact.
> 
> **Overview**
> MyST `{jinja}` fence parsing no longer requires an exact `{jinja}` info string. The **myst-parser** `SphinxJinja2Parser` now recognizes an optional named context after the directive (e.g. ` ```{jinja} ctx1`) and stores it in the region **`arguments`** lexeme instead of always using an empty string.
> 
> Argument-free ` ```{jinja}` blocks behave as before. Tests add parity coverage for both MyST parser implementations asserting `arguments == "ctx1"` for a named context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d44402d2fc196ffe7ef588ac34fee704f56c6ca5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->