### PR TITLE
Consume skip-next non-code targets

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -45,11 +45,14 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
             case ("end", object()):
                 in_skip_range = False
             case _:
+                skip_current = skip_next or in_skip_range
+                # ``skip: next`` targets the next non-marker example,
+                # whether or not that example has a source lexeme.
+                skip_next = False
                 if has_source(example=ex):
                     non_skip_count += 1
-                    if skip_next or in_skip_range:
+                    if skip_current:
                         skipped_count += 1
-                        skip_next = False
 
     return non_skip_count - skipped_count
 

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -1,6 +1,7 @@
 """Group-all parser tests shared across markup languages."""
 
 import subprocess
+import time
 import uuid
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
@@ -9,6 +10,12 @@ from pathlib import Path
 import pytest
 from beartype import beartype
 from sybil import Document, Example, Region, Sybil
+from sybil.parsers.rest import (
+    CodeBlockParser as RestCodeBlockParser,
+)
+from sybil.parsers.rest import (
+    DocTestParser,
+)
 from sybil.region import Lexeme
 
 from sybil_extras.evaluators.block_accumulator import BlockAccumulatorEvaluator
@@ -18,6 +25,52 @@ from sybil_extras.languages import (
     DirectiveBuilder,
     MarkupLanguage,
 )
+from sybil_extras.parsers.abstract._grouping_utils import (
+    count_expected_code_blocks,
+)
+from sybil_extras.parsers.rest.group_all import GroupAllParser
+from sybil_extras.parsers.rest.thread_safe_skip import ThreadSafeSkipParser
+
+
+def test_skip_next_non_code_example_is_consumed(tmp_path: Path) -> None:
+    """A non-code example consumes ``skip: next`` before grouping."""
+    content = """\
+.. custom-skip: next
+
+>>> 1 + 1
+2
+
+.. code-block:: python
+
+   x = 1
+"""
+    test_document = tmp_path / "test.rst"
+    test_document.write_text(data=content, encoding="utf-8")
+    evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
+    group_parser = GroupAllParser(evaluator=evaluator, pad_groups=False)
+    document = Sybil(
+        parsers=[
+            RestCodeBlockParser(
+                language="python",
+                evaluator=NoOpEvaluator(),
+            ),
+            DocTestParser(),
+            ThreadSafeSkipParser(directive="custom-skip"),
+            group_parser,
+        ]
+    ).parse(path=test_document)
+    examples = list(document.examples())
+
+    assert count_expected_code_blocks(examples=examples) == 1
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        final_result = executor.submit(examples[-1].evaluate)
+        time.sleep(0.05)
+        for example in examples[:-1]:
+            example.evaluate()
+        final_result.result(timeout=1)
+
+    assert document.namespace["blocks"] == ["x = 1"]
 
 
 @beartype

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -25,9 +25,6 @@ from sybil_extras.languages import (
     DirectiveBuilder,
     MarkupLanguage,
 )
-from sybil_extras.parsers.abstract._grouping_utils import (
-    count_expected_code_blocks,
-)
 from sybil_extras.parsers.rest.group_all import GroupAllParser
 from sybil_extras.parsers.rest.thread_safe_skip import ThreadSafeSkipParser
 
@@ -60,8 +57,6 @@ def test_skip_next_non_code_example_is_consumed(tmp_path: Path) -> None:
         ]
     ).parse(path=test_document)
     examples = list(document.examples())
-
-    assert count_expected_code_blocks(examples=examples) == 1
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         final_result = executor.submit(examples[-1].evaluate)

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -1,6 +1,7 @@
 """Group-all parser tests shared across markup languages."""
 
 import subprocess
+import textwrap
 import time
 import uuid
 from collections.abc import Iterable
@@ -31,16 +32,18 @@ from sybil_extras.parsers.rest.thread_safe_skip import ThreadSafeSkipParser
 
 def test_skip_next_non_code_example_is_consumed(tmp_path: Path) -> None:
     """A non-code example consumes ``skip: next`` before grouping."""
-    content = """\
-.. custom-skip: next
+    content = textwrap.dedent(
+        text="""\
+        .. custom-skip: next
 
->>> 1 + 1
-2
+        >>> 1 + 1
+        2
 
-.. code-block:: python
+        .. code-block:: python
 
-   x = 1
-"""
+           x = 1
+        """,
+    )
     test_document = tmp_path / "test.rst"
     test_document.write_text(data=content, encoding="utf-8")
     evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")


### PR DESCRIPTION
## Summary

- consume `skip: next` on the next non-marker example regardless of source lexemes
- count a following code block when a doctest was the skipped target
- add a regression that starts the group final marker before collection
- verify the final marker waits and emits the expected code block

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (888 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1075

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small logic change in skip-marker handling for block counting; covered by a targeted regression test and existing group-all skip tests.
> 
> **Overview**
> Fixes **group-all block counting** when `skip: next` targets an example that is not a collectable code block (e.g. a doctest).
> 
> In `count_expected_code_blocks`, **`skip: next` is now consumed on the next non-marker example** by snapshotting `skip_current` and clearing `skip_next` before the `has_source` check. Previously, `skip_next` stayed set until a source-bearing example appeared, so a skipped doctest could leave the flag active and wrongly exclude the following code block from the expected count—breaking finalize/wait logic under concurrent evaluation.
> 
> Adds a **reST regression test** (`skip: next` → doctest → code block) that evaluates the finalize marker early in a thread pool and asserts the code block still lands in the grouped output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbffa255d848616e5d2d1972eac652c72814cd97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->