### PR TITLE
Cancel pending skip-next at end

### DIFF
--- a/src/sybil_extras/parsers/abstract/_grouping_utils.py
+++ b/src/sybil_extras/parsers/abstract/_grouping_utils.py
@@ -44,6 +44,7 @@ def count_expected_code_blocks(examples: Iterable[Example]) -> int:
                 in_skip_range = True
             case ("end", object()):
                 in_skip_range = False
+                skip_next = False
             case _:
                 if has_source(example=ex):
                     non_skip_count += 1

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -19,9 +19,6 @@ from sybil_extras.languages import (
     DirectiveBuilder,
     MarkupLanguage,
 )
-from sybil_extras.parsers.abstract._grouping_utils import (
-    count_expected_code_blocks,
-)
 
 
 def test_skip_end_cancels_pending_next(
@@ -58,8 +55,6 @@ def test_skip_end_cancels_pending_next(
         ]
     ).parse(path=test_document)
     examples = list(document.examples())
-
-    assert count_expected_code_blocks(examples=examples) == 1
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         final_result = executor.submit(examples[-1].evaluate)

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -1,6 +1,7 @@
 """Group-all parser tests shared across markup languages."""
 
 import subprocess
+import time
 import uuid
 from collections.abc import Iterable
 from concurrent.futures import ThreadPoolExecutor
@@ -18,6 +19,56 @@ from sybil_extras.languages import (
     DirectiveBuilder,
     MarkupLanguage,
 )
+from sybil_extras.parsers.abstract._grouping_utils import (
+    count_expected_code_blocks,
+)
+
+
+def test_skip_end_cancels_pending_next(
+    *,
+    language_directive_builder: tuple[MarkupLanguage, DirectiveBuilder],
+    tmp_path: Path,
+) -> None:
+    """``skip: end`` cancels ``skip: next`` before block counting."""
+    language, directive_builder = language_directive_builder
+    content = language.markup_separator.join(
+        [
+            directive_builder(directive="custom-skip", argument="next"),
+            directive_builder(directive="custom-skip", argument="end"),
+            language.code_block_builder(code="x = 1", language="python"),
+        ]
+    )
+    test_document = tmp_path / "test"
+    test_document.write_text(
+        data=f"{content}{language.markup_separator}",
+        encoding="utf-8",
+    )
+    evaluator = BlockAccumulatorEvaluator(namespace_key="blocks")
+    document = Sybil(
+        parsers=[
+            language.code_block_parser_cls(
+                language="python",
+                evaluator=NoOpEvaluator(),
+            ),
+            language.thread_safe_skip_parser_cls(directive="custom-skip"),
+            language.group_all_parser_cls(
+                evaluator=evaluator,
+                pad_groups=False,
+            ),
+        ]
+    ).parse(path=test_document)
+    examples = list(document.examples())
+
+    assert count_expected_code_blocks(examples=examples) == 1
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        final_result = executor.submit(examples[-1].evaluate)
+        time.sleep(0.05)
+        for example in examples[:-1]:
+            example.evaluate()
+        final_result.result(timeout=1)
+
+    assert document.namespace["blocks"] == ["x = 1\n"]
 
 
 @beartype


### PR DESCRIPTION
## Summary

- clear pending `skip: next` state when processing `skip: end`
- align grouping’s expected-block counter with skipper semantics
- exercise the sequence across all supported markup variants
- start finalization first to verify it waits for the following code block

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (898 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1076

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line behavior change in skip-marker counting logic plus tests; no auth, I/O, or broad API surface.
> 
> **Overview**
> Fixes **group-all** block counting when **`skip: next`** is immediately followed by **`skip: end`**. Processing **`skip: end`** now clears the pending **`skip_next`** flag (in addition to closing a skip range), so the next code block is counted as expected instead of being treated as skipped.
> 
> Adds a shared parser test (all markup variants) for that directive sequence, including concurrent evaluation where finalization starts before other examples finish, asserting the following block is still grouped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d99e05c3533be4f074cdf05a314ca5e3705aa78d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->