### PR TITLE
Preserve Norg trailing blank lines

### DIFF
--- a/src/sybil_extras/parsers/norg/codeblock.py
+++ b/src/sybil_extras/parsers/norg/codeblock.py
@@ -49,7 +49,7 @@ class NorgVerbatimRangedTagLexer:
         # Must be at start of line (with optional leading whitespace)
         # Allow trailing whitespace after @end for consistency with opening
         self._closing_pattern = re.compile(
-            pattern=r"^\s*@end[^\S\n]*$",
+            pattern=r"^[^\S\n]*@end[^\S\n]*$",
             flags=re.MULTILINE,
         )
         self._mapping = mapping

--- a/tests/parsers/norg/test_codeblock.py
+++ b/tests/parsers/norg/test_codeblock.py
@@ -160,6 +160,16 @@ def test_code_block_with_blank_lines() -> None:
     assert region.parsed == "x = 1\n\ny = 2\n"
 
 
+def test_code_block_preserves_blank_lines_before_end() -> None:
+    """Blank lines immediately before ``@end`` remain in the source."""
+    text = "@code python\nx = 1\n\n\n@end\n"
+
+    (region,) = _parse(text=text)
+
+    assert region.parsed == "x = 1\n\n\n"
+    assert text[region.start : region.end] == text.rstrip("\n")
+
+
 def test_nested_code_markers_in_content() -> None:
     """Code blocks can contain text that looks like markers."""
     (region,) = _parse(


### PR DESCRIPTION
## Summary

- limit indentation matching before Norg `@end` markers to horizontal whitespace
- prevent the closing-tag regex from consuming preceding newlines
- preserve every blank line inside verbatim ranged tags
- verify parsed source and raw region boundaries

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (888 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1077

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small regex tweak in Norg code-block lexing with a focused regression test; no auth, data, or broader API impact.
> 
> **Overview**
> Fixes Norg verbatim `@code`…`@end` parsing so **blank lines immediately before `@end` stay in the extracted source** instead of being dropped.
> 
> The closing-tag regex in `NorgVerbatimRangedTagLexer` now uses **`[^\S\n]*` for leading indentation** (horizontal whitespace only) instead of **`^\s*`**, aligning with the opening tag and avoiding newline consumption when locating `@end`.
> 
> Adds **`test_code_block_preserves_blank_lines_before_end`**, asserting parsed content keeps trailing blank lines and that the region span matches the raw document.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b619057e89bb2c1b7f918710846e01f82a9b713e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->