### PR TITLE
Keep Norg regions on opening lines

### DIFF
--- a/src/sybil_extras/parsers/norg/codeblock.py
+++ b/src/sybil_extras/parsers/norg/codeblock.py
@@ -42,7 +42,7 @@ class NorgVerbatimRangedTagLexer:
         # Must be at start of line (with optional leading whitespace)
         # Use [^\S\n]+ instead of \s+ to avoid matching newlines
         self._opening_pattern = re.compile(
-            pattern=rf"^\s*@code(?:[^\S\n]+(?P<language>{language}))?$",
+            pattern=rf"^[^\S\n]*@code(?:[^\S\n]+(?P<language>{language}))?$",
             flags=re.MULTILINE,
         )
         # Pattern to match closing tag: @end

--- a/tests/parsers/norg/test_codeblock.py
+++ b/tests/parsers/norg/test_codeblock.py
@@ -105,6 +105,18 @@ def test_verbatim_ranged_tag_with_leading_whitespace() -> None:
     assert region.parsed == "x = 1\n"
 
 
+def test_region_excludes_blank_lines_before_opening() -> None:
+    """A region starts on its ``@code`` line, not an earlier blank
+    line.
+    """
+    text = "Introduction\n\n\n@code python\nx = 1\n@end\n"
+
+    (region,) = _parse(text=text)
+
+    assert region.start == text.index("@code")
+    assert text[region.start :].startswith("@code python")
+
+
 def test_multiple_code_blocks() -> None:
     """Multiple code blocks in the same document are all parsed."""
     regions = _parse(


### PR DESCRIPTION
## Summary

- limit indentation matching before Norg `@code` markers to horizontal whitespace
- prevent opening-tag searches from absorbing preceding blank lines
- keep region source locations anchored to the actual tag line
- retain support for indentation on the opening line

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100` (888 passed, 100% coverage)
- mypy, pyright, pyright-verifytypes, ty, pyrefly
- Ruff, Pylint, repository commit hooks

Closes #1078

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lexer regex tweak and a focused test; behavior change is limited to region start offsets when blank lines precede `@code`.
> 
> **Overview**
> Fixes Norg `@code` region boundaries so **`region.start` sits on the `@code` line**, not on earlier blank lines after prose.
> 
> The opening-tag regex in `NorgVerbatimRangedTagLexer` now uses **`^[^\S\n]*`** (horizontal whitespace only) instead of **`^\s*`** before `@code`, matching the lexer’s existing rule of not treating newlines as indentation. Indented opening lines still work; only vertical whitespace is excluded from the prefix match.
> 
> Adds **`test_region_excludes_blank_lines_before_opening`** to lock in correct offsets when blank lines precede the tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f8ede9b3f77bb7c5f4327e40a383416c263248a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->