### PR TITLE
Keep Norg directive regions on their own lines

### DIFF
--- a/src/sybil_extras/parsers/norg/lexers.py
+++ b/src/sybil_extras/parsers/norg/lexers.py
@@ -41,7 +41,7 @@ class DirectiveInNorgCommentLexer:
         # The tag must be at the beginning of a line (with optional leading
         # whitespace)
         pattern = (
-            rf"^\s*\.(?P<directive>{directive})"
+            rf"^[^\S\n]*\.(?P<directive>{directive})"
             rf"(?:\s*:\s*(?P<arguments>{arguments}))?$"
         )
         self.pattern: re.Pattern[str] = re.compile(

--- a/tests/parsers/norg/test_lexers.py
+++ b/tests/parsers/norg/test_lexers.py
@@ -86,6 +86,18 @@ def test_directive_with_leading_whitespace() -> None:
     )
 
 
+def test_directive_region_excludes_preceding_blank_lines() -> None:
+    """A directive region starts on its own line."""
+    lexer = DirectiveInNorgCommentLexer(directive="skip", arguments=r".+")
+    source_text = "Introduction\n\n\n  .skip: next\n"
+    document = Document(text=source_text, path="sample.norg")
+
+    (region,) = list(lexer(document))
+
+    assert region.start == source_text.index("  .skip")
+    assert source_text[region.start : region.end] == "  .skip: next"
+
+
 def test_verbatim_ranged_tag_lexer_no_mapping() -> None:
     """The verbatim ranged tag lexer works without a mapping."""
     lexer = NorgVerbatimRangedTagLexer(language=r"python")


### PR DESCRIPTION
## Summary

- restrict leading directive indentation to horizontal whitespace
- prevent directive regions from absorbing preceding blank lines
- add a regression for an indented directive after multiple blank lines

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- mypy, pyright, pyright-verifytypes, ty, and pyrefly pre-push hooks
- Ruff and Pylint on changed files

Closes #1079

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small regex change in Norg parsing with a focused regression test; behavior is more precise for skip/group directives, not security-critical infrastructure.
> 
> **Overview**
> **Tightens how `DirectiveInNorgCommentLexer` anchors directives at line starts** so emitted `Region` spans cover only the directive line (plus allowed indentation), not blank lines above it.
> 
> The regex leading prefix changes from `^\s*` to `^[^\S\n]*`, so only horizontal whitespace may precede the `.directive` token; newlines can no longer be treated as part of that prefix. That affects skip and grouped-source parsers that rely on this lexer for region boundaries.
> 
> A regression test asserts that after multiple blank lines, an indented `.skip: …` region starts at the spaces before the dot and ends with the directive text only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e01c137275bba053c0a0a5ba5d77b41c7d36e404. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->