### PR TITLE
Keep Djot directive regions on their own lines

### DIFF
--- a/src/sybil_extras/parsers/djot/lexers.py
+++ b/src/sybil_extras/parsers/djot/lexers.py
@@ -43,7 +43,7 @@ class DirectiveInDjotCommentLexer:
         # Arguments use (?:(?!\%\}).)*? to stop at %} but allow % otherwise.
         # The user's arguments pattern is applied as a filter afterwards.
         pattern = (
-            rf"^\s*\{{\%\s*(?P<directive>{directive})"
+            rf"^[^\S\n]*\{{\%\s*(?P<directive>{directive})"
             rf"(?:\s*:\s*(?P<arguments>(?:(?!\%\}}).)*?))?\s*\%\}}"
         )
         self.pattern: re.Pattern[str] = re.compile(

--- a/tests/parsers/djot/test_lexers.py
+++ b/tests/parsers/djot/test_lexers.py
@@ -69,6 +69,18 @@ def test_directive_with_mapping() -> None:
     )
 
 
+def test_directive_region_excludes_preceding_blank_lines() -> None:
+    """A directive region starts on its own line."""
+    lexer = DirectiveInDjotCommentLexer(directive="skip", arguments=r".+")
+    source_text = "Introduction\n\n\n  {% skip: next %}\n"
+    document = Document(text=source_text, path="sample.djot")
+
+    (region,) = list(lexer(document))
+
+    assert region.start == source_text.index("  {% skip")
+    assert source_text[region.start : region.end] == "  {% skip: next %}"
+
+
 def test_directive_stops_at_first_closing_delimiter() -> None:
     """Djot comments end at the first ``%}``, so text after it is not
     captured.


### PR DESCRIPTION
## Summary

- restrict leading directive indentation to horizontal whitespace
- prevent Djot directive regions from absorbing preceding blank lines
- add a regression for an indented directive after multiple blank lines

## Validation

- `uv run --extra=dev pytest -q -o log_cli=false . --cov=src --cov=tests --cov-report=term-missing:skip-covered --cov-fail-under=100`
- mypy, pyright, pyright-verifytypes, ty, and pyrefly pre-push hooks
- Ruff and Pylint on changed files

Closes #1080

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small regex change in Djot directive lexing with a targeted regression test; no auth, data, or broad API impact.
> 
> **Overview**
> **Djot comment directive regions** no longer include preceding blank lines: `DirectiveInDjotCommentLexer` now allows only horizontal whitespace before `{% ... %}` (`^[^\S\n]*` instead of `^\s*`), so `Region.start`/`end` align with the directive line.
> 
> Adds a regression test for an indented directive after multiple blank lines (e.g. `Introduction` then blank lines then `{% skip: next %}`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645f0caadcc74e5bac60fc3b864903aa3c0ada7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->