### PR TITLE
Remove obsolete bdist_wheel.universal setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,6 @@ package-data.sybil_extras = [
 ]
 zip-safe = false
 
-[tool.distutils]
-bdist_wheel.universal = true
-
 [tool.setuptools_scm]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary
- Remove `[tool.distutils] bdist_wheel.universal = true` from `pyproject.toml`.
- Universal wheels falsely claim Python 2 support and trigger setuptools deprecation warnings on every build.

## Test plan
- [ ] Confirm package still builds a normal (non-universal) wheel
- [ ] Confirm CI passes

Made with [Cursor](https://cursor.com)