### PR TITLE
Fix empty blockquote code block write regression

### DIFF
--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -273,7 +273,7 @@ def _get_modified_region_text(
         text=edit.replace_old_not_indented,
         prefix=edit.within_code_block_indent_prefix,
     )
-    if ">" in edit.within_code_block_indent_prefix:
+    if example.parsed and ">" in edit.within_code_block_indent_prefix:
         prefixed_blank_lines = textwrap.indent(
             text=edit.replace_old_not_indented,
             prefix=edit.within_code_block_indent_prefix,


### PR DESCRIPTION
## Problem

`main` is currently red: `test_empty_blockquote_code_block_write_content` fails with `ValueError: Parsed code is not contiguous in its source region; grouped examples cannot be written`.

This is a latent interaction between three recently-merged code-block-writer PRs that were merged sequentially without re-running CI against the final combination:

- **#1091** bounded the empty-block insertion search to `original_region_text[:source_offset]`.
- **#1093** added a `>`-prefix recomputation of the insertion placeholder for blank lines inside **non-empty** quoted content.
- **#1092** added empty-blockquote writing.

For an **empty** blockquoted fence (`> ```python\n> ```\n`), `example.parsed` is falsy, but #1093's recomputation still ran and rewrote the placeholder from `"\n"` to `"> \n"` — which is absent from #1091's bounded search region (just the opening line), so the #1088 contiguity guard raised.

## Fix

Guard the `>`-prefix recomputation with `example.parsed`, so it only applies to non-empty quoted content (#1093's actual target). Empty-blockquote writes (#1092) again find the plain `"\n"` placeholder; blank-line-in-quoted-content handling (#1093) is unchanged.

## Verification

- The 3 failing `test_empty_blockquote_code_block_write_content` params now pass.
- Full suite: 947 passed, 100% coverage.
- mypy, pyright, ty, pyrefly, ruff, pylint all clean; pre-push hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional change in code-block write path; limits an existing rewrite to parsed (non-empty) examples only.
> 
> **Overview**
> Fixes a regression where writing into an **empty** blockquoted fenced code block (`> ```python` / `> ````) raised *Parsed code is not contiguous in its source region*.
> 
> The blockquote blank-line placeholder logic (when `>` is in the indent prefix) now runs only when **`example.parsed` is truthy**, i.e. non-empty quoted content. Empty blocks keep the plain `"\n"` insertion target that the bounded search region expects; behavior for non-empty quoted blocks is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77caeaa13833aba00342fe242037413453f98e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->