### PR TITLE
Error clearly when a changed pycon statement can no longer keep its output

### DIFF
--- a/newsfragments/1110.change
+++ b/newsfragments/1110.change
@@ -1,0 +1,1 @@
+The pycon shell evaluator now raises a clear error when a command changes a statement's meaning, instead of silently reattaching the original (now stale) recorded output.

--- a/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
@@ -12,6 +12,7 @@ from beartype import beartype
 
 from sybil_extras.evaluators.shell_evaluator.exceptions import (
     InvalidPyconError,
+    PyconOutputMismatchError,
 )
 
 
@@ -66,6 +67,7 @@ class _PyconChunk:
     """A parsed pycon interaction chunk."""
 
     output_lines: list[str]
+    python_text: str
 
 
 @beartype
@@ -90,21 +92,38 @@ class _PyconTranscript:
         """
         chunks: list[_PyconChunk] = []
         current_output: list[str] = []
+        current_input: list[str] = []
         seen_prompt = False
 
         for line in pycon_text.splitlines(keepends=True):
             stripped = line.rstrip("\n\r")
             if stripped == ">>>" or line.startswith(">>> "):
                 if seen_prompt:
-                    chunks.append(_PyconChunk(output_lines=current_output))
+                    chunks.append(
+                        _PyconChunk(
+                            output_lines=current_output,
+                            python_text=pycon_to_python(
+                                pycon_text="".join(current_input),
+                            ),
+                        )
+                    )
                     current_output = []
+                    current_input = []
                 seen_prompt = True
+                current_input.append(line)
             elif stripped == "..." or line.startswith("... "):
-                pass
+                current_input.append(line)
             else:
                 current_output.append(line)
 
-        chunks.append(_PyconChunk(output_lines=current_output))
+        chunks.append(
+            _PyconChunk(
+                output_lines=current_output,
+                python_text=pycon_to_python(
+                    pycon_text="".join(current_input),
+                ),
+            )
+        )
 
         return cls(chunks=chunks)
 
@@ -170,6 +189,55 @@ def _is_separator_group(*, group: list[str]) -> bool:
 
 
 @beartype
+def _ast_equivalent(*, first: str, second: str) -> bool:
+    """Return True if two Python snippets are equivalent.
+
+    Equivalence is determined by comparing the abstract syntax trees, so
+    pure reformatting (such as ``1+1`` and ``1 + 1``) is treated as
+    equivalent while meaning-changing rewrites (such as ``1 + 1`` and
+    ``1 + 2``) are not.  If either snippet cannot be parsed, fall back to
+    comparing the text exactly.
+    """
+    try:
+        first_tree = ast.parse(source=first)
+        second_tree = ast.parse(source=second)
+    except SyntaxError:
+        return first == second
+    return ast.dump(node=first_tree) == ast.dump(node=second_tree)
+
+
+@beartype
+def _require_preservable_output(
+    *,
+    groups: list[list[str]],
+    chunks: list[_PyconChunk],
+) -> None:
+    """Ensure each reformatted group can keep its chunk's recorded output.
+
+    For a 1:1 group-to-chunk mapping, a group's output may only be
+    preserved when the reformatted statement is still equivalent to the
+    original.  When a chunk with recorded output maps to a group whose
+    meaning changed, raise rather than reattach stale output.
+
+    Raises:
+        PyconOutputMismatchError: If a reformatted statement changed the
+            meaning of an original chunk that has recorded output.
+    """
+    for group, chunk in zip(groups, chunks, strict=True):
+        if not chunk.output_lines:
+            continue
+        reformatted = pycon_to_python(pycon_text="".join(group))
+        if not _ast_equivalent(first=reformatted, second=chunk.python_text):
+            msg = (
+                "The command changed the meaning of a pycon statement "
+                f"(from {chunk.python_text!r} to {reformatted!r}), so its "
+                "recorded output can no longer be safely preserved. Update "
+                "the pycon transcript manually to reflect the new output."
+            )
+            raise PyconOutputMismatchError(msg)
+
+
+@beartype
 def _render_pycon_from_python(
     *,
     python_text: str,
@@ -203,7 +271,11 @@ def _render_pycon_from_python(
     # check if the *substantive* groups match the original chunks.
     chunk_for_group: list[int | None]
     if len(groups) == len(original_chunks):
-        # Direct 1:1 match - every group gets its chunk's output.
+        # Direct 1:1 match - every group gets its chunk's output, but only
+        # when the reformatted statement still means the same thing as the
+        # original.  Otherwise the recorded output would be reattached to a
+        # statement it no longer describes.
+        _require_preservable_output(groups=groups, chunks=original_chunks)
         chunk_for_group = list(range(len(groups)))
     else:
         substantive = [
@@ -246,6 +318,11 @@ def python_to_pycon(*, python_text: str, original_pycon: str) -> str:
 
     Returns:
         The pycon-formatted version of ``python_text``.
+
+    Raises:
+        PyconOutputMismatchError: If a reformatted statement mapped 1:1 to
+            an original chunk changed the statement's meaning, so its
+            recorded output can no longer be safely preserved.
     """
     transcript = _PyconTranscript.from_text(pycon_text=original_pycon)
     return _render_pycon_from_python(

--- a/src/sybil_extras/evaluators/shell_evaluator/exceptions.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/exceptions.py
@@ -8,3 +8,13 @@ class InvalidPyconError(ValueError):
     """Raised when pycon content contains lines before the first
     prompt.
     """
+
+
+@beartype
+class PyconOutputMismatchError(ValueError):
+    """Raised when a reformatted pycon statement changed its meaning.
+
+    When a command rewrites what a statement does (rather than merely
+    reformatting it), the recorded output from the original transcript can
+    no longer be safely reattached, so this error is raised instead.
+    """

--- a/tests/evaluators/test_pycon_shell_evaluator.py
+++ b/tests/evaluators/test_pycon_shell_evaluator.py
@@ -15,6 +15,7 @@ from sybil.parsers.markdown import (
 from sybil_extras.evaluators.shell_evaluator import ShellCommandEvaluator
 from sybil_extras.evaluators.shell_evaluator.exceptions import (
     InvalidPyconError,
+    PyconOutputMismatchError,
 )
 from sybil_extras.evaluators.shell_evaluator.result_transformer import (
     PyconResultTransformer,
@@ -502,6 +503,164 @@ def test_write_to_file_statement_count_mismatch(
         ```
         """,
     )
+
+
+def test_write_to_file_preserves_output_on_equivalent_reformat(
+    *,
+    tmp_path: Path,
+) -> None:
+    """Pure reformatting of a statement keeps its recorded output.
+
+    ``1+1`` and ``1 + 1`` are AST-equivalent, so the recorded ``2`` output
+    is preserved even though the statement text changed.
+    """
+    content = textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> 1+1
+        2
+        ```
+        """,
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    script = tmp_path / "fmt.py"
+    script.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import sys, pathlib
+            path = pathlib.Path(sys.argv[1])
+            path.write_text(path.read_text().replace("1+1", "1 + 1"))
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    evaluator = _make_pycon_evaluator(
+        args=["python3", str(object=script)],
+        write_to_file=True,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="pycon",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    (example,) = document.examples()
+    example.evaluate()
+
+    result = test_file.read_text(encoding="utf-8")
+    assert result == textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> 1 + 1
+        2
+        ```
+        """,
+    )
+
+
+def test_write_to_file_meaning_change_raises(
+    *,
+    tmp_path: Path,
+) -> None:
+    """A statement whose meaning changed cannot keep its recorded output.
+
+    Rewriting ``1 + 1`` to ``1 + 2`` changes the AST, so reattaching the
+    recorded ``2`` would be wrong.  The evaluator raises instead, and the
+    source file is left untouched.
+    """
+    content = textwrap.dedent(
+        text="""\
+        ```pycon
+        >>> 1 + 1
+        2
+        ```
+        """,
+    )
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    script = tmp_path / "fmt.py"
+    script.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import sys, pathlib
+            path = pathlib.Path(sys.argv[1])
+            path.write_text(path.read_text().replace("1 + 1", "1 + 2"))
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    evaluator = _make_pycon_evaluator(
+        args=["python3", str(object=script)],
+        write_to_file=True,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="pycon",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    (example,) = document.examples()
+
+    with pytest.raises(
+        expected_exception=PyconOutputMismatchError,
+        match="changed the meaning of a pycon statement",
+    ):
+        example.evaluate()
+
+    # The source file is not silently corrupted.
+    assert test_file.read_text(encoding="utf-8") == content
+
+
+def test_write_to_file_unparseable_original_change_raises(
+    *,
+    tmp_path: Path,
+) -> None:
+    """An original statement that cannot be parsed uses the text fallback.
+
+    The original statement is indented, so it cannot be AST-parsed on its
+    own.  The formatter dedents it, changing the text, so the recorded
+    output can no longer be safely preserved and an error is raised.
+    """
+    content = "```pycon\n>>>     x = 1\n1\n```\n"
+    test_file = tmp_path / "test.md"
+    test_file.write_text(data=content, encoding="utf-8")
+
+    script = tmp_path / "fmt.py"
+    script.write_text(
+        data=textwrap.dedent(
+            text="""\
+            import sys, pathlib
+            path = pathlib.Path(sys.argv[1])
+            path.write_text(path.read_text().lstrip())
+            """,
+        ),
+        encoding="utf-8",
+    )
+
+    evaluator = _make_pycon_evaluator(
+        args=["python3", str(object=script)],
+        write_to_file=True,
+    )
+    parser = SybilMarkdownCodeBlockParser(
+        language="pycon",
+        evaluator=evaluator,
+    )
+    sybil = Sybil(parsers=[parser])
+    document = sybil.parse(path=test_file)
+    (example,) = document.examples()
+
+    with pytest.raises(
+        expected_exception=PyconOutputMismatchError,
+        match="changed the meaning of a pycon statement",
+    ):
+        example.evaluate()
+
+    assert test_file.read_text(encoding="utf-8") == content
 
 
 def test_write_to_file_preserves_output_when_formatter_adds_blank_line(


### PR DESCRIPTION
## Summary

When the shell evaluator rewrites a pycon transcript after formatting, `_render_pycon_from_python()` reattaches the original interactive output whenever the number of `>>>` prompt groups equals the number of original chunks. It never checked whether each statement was actually *unchanged*, so a command that changed a statement's **meaning** (not just its formatting) would get stale output reattached to a now-different statement.

## What changed

- `_PyconChunk` gains a `python_text` field, populated in `_PyconTranscript.from_text` from the original transcript input.
- New `_ast_equivalent()` helper compares two Python snippets via `ast.parse` + `ast.dump`, with a **text-equality fallback on `SyntaxError`**.
- In the 1:1 group-to-chunk mapping case only, for each mapped group that has recorded output, the reformatted statement is compared to its original input. If they are **not** equivalent, a clear `PyconOutputMismatchError` is raised instead of silently preserving stale output.
- Pure reformatting (`1+1` -> `1 + 1`) stays AST-equivalent and preserves output as before. Only meaning-changing rewrites (`1 + 1` -> `1 + 2`) error.
- When the group count already differs from the chunk count, behavior is untouched (we don't map/preserve there today).

The error propagates through the shell evaluator's `write_to_file` path and surfaces as a failure; the source file is left intact (the namespace write never happens).

## Error message

> The command changed the meaning of a pycon statement (from '...' to '...'), so its recorded output can no longer be safely preserved. Update the pycon transcript manually to reflect the new output.

## Tests (end-to-end through the shell evaluator `write_to_file` path)

- Meaning-changing rewrite (`1 + 1` -> `1 + 2`) raises `PyconOutputMismatchError`; source file left intact.
- Unparseable original statement (indented, dedented by the formatter) exercises the `SyntaxError` text-equality fallback and raises.
- Pure reformatting (`1+1` -> `1 + 1`) still preserves output with no error.
- Existing round-trip / no-change / mismatch tests are unchanged.

## Verification

- `pytest . --cov=src --cov=tests --cov-fail-under=100`: 969 passed, 100% coverage.
- `prek run --all-files --hook-stage pre-commit`: all hooks pass (ruff, pylint, mypy, pyright, pyright-verifytypes, ty, pyrefly).

Closes #1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted change to pycon transcript rendering with explicit failure modes; docs/tests only elsewhere, no auth or data-path impact.
> 
> **Overview**
> The pycon shell evaluator’s **write-to-file** round-trip no longer reattaches original interactive output when a formatter **changes what a statement means**—only when it is still equivalent (AST-based, with a text fallback on parse failure).
> 
> **`_PyconTranscript`** now stores each chunk’s original input as `python_text`. On a **1:1** match between prompt groups and chunks, **`_require_preservable_output`** compares reformatted code to that snapshot; mismatches raise **`PyconOutputMismatchError`** with guidance to update the transcript manually, and the source file stays unchanged. Pure formatting (e.g. `1+1` → `1 + 1`) still keeps output; semantic edits (e.g. `1 + 1` → `1 + 2`) fail. Behavior when group and chunk counts differ is unchanged.
> 
> End-to-end tests cover equivalent reformat, meaning change, and unparseable-original text fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14ca1d652616a0e4b94e8f8380eaeee6d6321290. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->