### PR TITLE
Move reST literal-block formatting out of the empty-block writer (closes #1111, #1066)

### DIFF
--- a/spelling_private_dict.txt
+++ b/spelling_private_dict.txt
@@ -54,5 +54,6 @@ truthy
 typeshed
 unclosed
 ungrouped
+unindented
 variadic
 whitespace

--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -19,6 +19,10 @@ from beartype import beartype
 from sybil import Document, Example, Lexeme
 from sybil.typing import Evaluator
 
+CONTENT_INDENT_LEXEME = "content_indent"
+
+CONTENT_SEPARATOR_LEXEME = "content_separator"
+
 
 @dataclass
 class _CapturedValue:
@@ -196,6 +200,8 @@ def _empty_block_region_edit(
     original_region_text: str,
     code_block_indent_prefix: str,
     source_offset: int,
+    content_indent: str,
+    content_separator: str,
 ) -> _RegionEdit:
     """Describe how to insert content into an *empty* code block.
 
@@ -210,8 +216,11 @@ def _empty_block_region_edit(
       content, so the content goes at the block's own indentation, just
       before that line.
     * No closing delimiter means an indented literal block (as in
-      reStructuredText), whose content is an indented sub-block separated
-      from the opening line by a blank line.
+      reStructuredText), whose content is an indented sub-block. Its
+      placement -- the extra ``content_indent`` beyond the block's own
+      indentation and the ``content_separator`` between the opening line and
+      the content -- is supplied by the parser, so no markup-specific
+      formatting lives here.
     """
     closing_delimiter = original_region_text[source_offset:]
     has_closing_delimiter = bool(closing_delimiter.strip())
@@ -229,9 +238,10 @@ def _empty_block_region_edit(
         )
 
     return _RegionEdit(
-        within_code_block_indent_prefix=code_block_indent_prefix + "   ",
+        within_code_block_indent_prefix=code_block_indent_prefix
+        + content_indent,
         replace_old_not_indented="\n",
-        replace_new_prefix="\n\n",
+        replace_new_prefix=content_separator,
     )
 
 
@@ -262,10 +272,15 @@ def _get_modified_region_text(
         search_region_text = original_region_text
     else:
         source_offset = _source_offset(example=example)
+        lexemes = example.region.lexemes
         edit = _empty_block_region_edit(
             original_region_text=original_region_text,
             code_block_indent_prefix=code_block_indent_prefix,
             source_offset=source_offset,
+            content_indent=str(object=lexemes.get(CONTENT_INDENT_LEXEME, "")),
+            content_separator=str(
+                object=lexemes.get(CONTENT_SEPARATOR_LEXEME, "\n")
+            ),
         )
         search_region_text = original_region_text[:source_offset]
 

--- a/src/sybil_extras/languages.py
+++ b/src/sybil_extras/languages.py
@@ -7,7 +7,6 @@ from typing import Protocol, runtime_checkable
 
 import sybil.parsers.markdown
 import sybil.parsers.myst
-import sybil.parsers.rest
 from beartype import beartype
 from sybil import Document, Region
 from sybil.evaluators.skip import Skipper
@@ -48,6 +47,7 @@ import sybil_extras.parsers.norg.custom_directive_skip
 import sybil_extras.parsers.norg.group_all
 import sybil_extras.parsers.norg.grouped_source
 import sybil_extras.parsers.norg.thread_safe_skip
+import sybil_extras.parsers.rest.codeblock
 import sybil_extras.parsers.rest.custom_directive_skip
 import sybil_extras.parsers.rest.group_all
 import sybil_extras.parsers.rest.grouped_source
@@ -359,7 +359,7 @@ RESTRUCTUREDTEXT = MarkupLanguage(
     thread_safe_skip_parser_cls=(
         sybil_extras.parsers.rest.thread_safe_skip.ThreadSafeSkipParser
     ),
-    code_block_parser_cls=sybil.parsers.rest.CodeBlockParser,
+    code_block_parser_cls=sybil_extras.parsers.rest.codeblock.CodeBlockParser,
     group_parser_cls=sybil_extras.parsers.rest.grouped_source.GroupedSourceParser,
     group_all_parser_cls=sybil_extras.parsers.rest.group_all.GroupAllParser,
     sphinx_jinja_parser_cls=sybil_extras.parsers.rest.sphinx_jinja2.SphinxJinja2Parser,

--- a/src/sybil_extras/parsers/rest/_content_placement.py
+++ b/src/sybil_extras/parsers/rest/_content_placement.py
@@ -1,0 +1,27 @@
+"""Structural placement of content within reStructuredText blocks.
+
+reStructuredText directive bodies (such as ``.. code-block::``) are
+indented literal blocks: their content is indented relative to the
+directive marker and separated from it by a blank line. This module
+records that markup-specific placement on each region as lexemes so that
+the language-agnostic code block writer can insert content into an
+*empty* block without needing to know any reStructuredText formatting.
+"""
+
+from beartype import beartype
+from sybil import Region
+
+from sybil_extras.evaluators.code_block_writer import (
+    CONTENT_INDENT_LEXEME,
+    CONTENT_SEPARATOR_LEXEME,
+)
+
+_LITERAL_BLOCK_INDENT = "   "
+_LITERAL_BLOCK_SEPARATOR = "\n\n"
+
+
+@beartype
+def attach_content_placement(*, region: Region) -> None:
+    """Record reStructuredText content placement on ``region``."""
+    region.lexemes[CONTENT_INDENT_LEXEME] = _LITERAL_BLOCK_INDENT
+    region.lexemes[CONTENT_SEPARATOR_LEXEME] = _LITERAL_BLOCK_SEPARATOR

--- a/src/sybil_extras/parsers/rest/codeblock.py
+++ b/src/sybil_extras/parsers/rest/codeblock.py
@@ -1,0 +1,46 @@
+"""A reStructuredText code block parser.
+
+This wraps Sybil's stock reStructuredText code block parser to record the
+structural placement of content within each region (see
+:mod:`sybil_extras.parsers.rest._content_placement`), so that the
+code block writer can insert content into empty blocks without knowing
+any reStructuredText-specific formatting.
+"""
+
+from collections.abc import Iterable
+
+import sybil.parsers.rest
+from beartype import beartype
+from sybil import Document, Region
+from sybil.typing import Evaluator
+
+from sybil_extras.parsers.rest._content_placement import (
+    attach_content_placement,
+)
+
+
+@beartype
+class CodeBlockParser:
+    """A parser for reStructuredText code blocks."""
+
+    def __init__(
+        self,
+        *,
+        language: str | None = None,
+        evaluator: Evaluator | None = None,
+    ) -> None:
+        """
+        Args:
+            language: The language to match (for example ``python``).
+            evaluator: The evaluator used for the parsed code block.
+        """
+        self._parser = sybil.parsers.rest.CodeBlockParser(
+            language=language,
+            evaluator=evaluator,
+        )
+
+    def __call__(self, document: Document) -> Iterable[Region]:
+        """Yield regions for code blocks, recording content placement."""
+        for region in self._parser(document):
+            attach_content_placement(region=region)
+            yield region

--- a/src/sybil_extras/parsers/rest/sphinx_jinja2.py
+++ b/src/sybil_extras/parsers/rest/sphinx_jinja2.py
@@ -9,6 +9,10 @@ from sybil.parsers.abstract.lexers import LexerCollection
 from sybil.parsers.rest.lexers import DirectiveLexer
 from sybil.typing import Evaluator
 
+from sybil_extras.parsers.rest._content_placement import (
+    attach_content_placement,
+)
+
 
 @beartype
 class SphinxJinja2Parser:
@@ -36,4 +40,5 @@ class SphinxJinja2Parser:
         for region in self._lexers(document):
             region.parsed = region.lexemes["source"]
             region.evaluator = self._evaluator
+            attach_content_placement(region=region)
             yield region

--- a/tests/evaluators/test_code_block_writer.py
+++ b/tests/evaluators/test_code_block_writer.py
@@ -663,6 +663,46 @@ def test_empty_tilde_fenced_block(tmp_path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    argnames="markup_language",
+    argvalues=(MARKDOWN_IT, MYST_PARSER),
+)
+def test_empty_fenced_block_closing_fence_trailing_spaces(
+    *,
+    tmp_path: Path,
+    markup_language: MarkupLanguage,
+) -> None:
+    """Trailing spaces after an empty block's closing fence are preserved.
+
+    Trailing spaces after a closing fence are legal Markdown, and the block
+    is still empty. Content is inserted unindented between the fences and
+    the trailing spaces are left untouched.
+    """
+    source_file = tmp_path / "source_file.md"
+    source_file.write_text(data="```python\n```   \n", encoding="utf-8")
+
+    def modifying_evaluator(example: Example) -> None:
+        """Store modified content in the namespace."""
+        example.document.namespace["modified_content"] = "inserted"
+
+    writer_evaluator = CodeBlockWriterEvaluator(evaluator=modifying_evaluator)
+    parser = markup_language.code_block_parser_cls(
+        language="python",
+        evaluator=writer_evaluator,
+    )
+    document = Sybil(parsers=[parser]).parse(path=source_file)
+    (example,) = document.examples()
+
+    example.evaluate()
+
+    assert source_file.read_text(encoding="utf-8") == (
+        "```python\ninserted\n```   \n"
+    )
+    reparsed_document = Sybil(parsers=[parser]).parse(path=source_file)
+    (reparsed_example,) = reparsed_document.examples()
+    assert str(object=reparsed_example.parsed) == "inserted\n"
+
+
 def test_empty_code_block_with_options(
     *,
     tmp_path: Path,

--- a/tests/parsers/test_sphinx_jinja2.py
+++ b/tests/parsers/test_sphinx_jinja2.py
@@ -147,6 +147,8 @@ def test_sphinx_jinja2_rst(
         "arguments": None,
         "source": "Hallo {{ name }}!\n",
         "options": {"ctx": '{"name": "World"}'},
+        "content_indent": "   ",
+        "content_separator": "\n\n",
     }
     first_example.evaluate()
 
@@ -159,4 +161,6 @@ def test_sphinx_jinja2_rst(
             "file": "templates/example1.jinja",
             "ctx": '{"name": "World"}',
         },
+        "content_indent": "   ",
+        "content_separator": "\n\n",
     }


### PR DESCRIPTION
## Summary

Two related changes to the code block writer's empty-block insertion path.

### Part A — #1111 (refactor)

`_empty_block_region_edit` hardcoded reStructuredText literal-block formatting: a 3-space content indent (`code_block_indent_prefix + "   "`) and a blank-line separator (`replace_new_prefix="\n\n"`). These are markup-specific and, for an *empty* block, genuinely underivable from the region's own generic data (there is no content line to measure, and the blank-line separator cannot be inferred from indentation depth — block quotes are an indentation counterexample).

Deriving them in the writer by re-inspecting the `.. ` marker would reintroduce the markup token-sniffing that the previous structural refactor deliberately removed. So instead the reST parsers now **hand the writer the placement** (issue option 1): they attach `content_indent` and `content_separator` lexemes to their regions, and the writer consumes them. `_empty_block_region_edit` contains no markup-specific literals.

- New `parsers/rest/codeblock.py` wraps the stock reST code block parser and attaches the lexemes; `RESTRUCTUREDTEXT.code_block_parser_cls` now points at it.
- `parsers/rest/sphinx_jinja2.py` attaches the same lexemes (preserves empty reST jinja-block writing).
- Shared reST constants live in `parsers/rest/_content_placement.py`; the generic lexeme-key names are defined by the writer (the consumer/contract owner).
- The writer reads the lexemes with generic defaults (`""` / `"\n"`), so delimited (Markdown/MyST/Norg) empty blocks are unaffected and no reST literal survives in the writer.

Behavior is byte-for-byte unchanged: every existing empty-block expected output in `tests/evaluators/test_code_block_writer.py` and `tests/test_languages.py` still passes verbatim. The only updated expectation is the structural lexemes-dict assertion in `tests/parsers/test_sphinx_jinja2.py`, which now includes the two new lexemes.

### Part B — #1066 (regression test)

Adds `test_empty_fenced_block_closing_fence_trailing_spaces` (parametrized over MarkdownIt and MyST parsers): writing into `` ```python\n```   \n `` yields `` ```python\ninserted\n```   \n `` and reparses to `inserted\n`. Passes both before and after Part A.

Closes #1111
Closes #1066

## Verification

- `pytest` with 100% coverage: 968 passed, coverage 100.00%.
- pre-commit hooks (ruff, pylint via manual/deptry, interrogate, etc.): all pass.
- pre-push type checkers: mypy, pyright, pyright-verifytypes, ty all pass. (pyrefly passes when run directly on the changed files; its pre-push hook reports "no files matched" only because this worktree lives under a gitignored path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor preserves documented byte-for-byte reST empty-block behavior via lexemes; fenced formats use safe defaults and existing tests cover the writer path.
> 
> **Overview**
> **Empty-block insertion** no longer hardcodes reStructuredText literal-block rules (3-space content indent and `\n\n` separator) inside `code_block_writer`. The writer now reads optional region lexemes `content_indent` and `content_separator` (defaults `""` / `"\n"`), so fenced Markdown/MyST/Norg behavior stays unchanged while reST-specific formatting lives in parsers.
> 
> reST **code-block** parsing is routed through a new wrapper around Sybil’s stock parser that attaches those lexemes via `attach_content_placement`; the same attachment is applied in the reST **sphinx-jinja2** parser. `RESTRUCTUREDTEXT.code_block_parser_cls` points at the new parser.
> 
> A parametrized test locks in writing into an empty fenced block whose closing fence has **trailing spaces**, preserving those spaces on disk and after reparse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7997cba93409bacc589228bc1beb84a424c926c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->