### PR TITLE
Use prek action with autofix.ci

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+
+  - package-ecosystem: pre-commit
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,37 @@
+---
+name: autofix.ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v9.0.0
+
+      - name: Run fixers
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage pre-commit --no-fail-fast --verbose
+        env:
+          UV_NO_CACHE: '1'
+          UV_PYTHON: 3.13
+
+      - uses: autofix-ci/action@v1.3.4
+        if: always()

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,16 +35,14 @@ jobs:
           cache-dependency-glob: '**/pyproject.toml'
 
       - name: Lint
-        # Use bash to ensure the step fails if any command fails.
-        # PowerShell does not fail on intermediate command failures by default.
-        shell: bash
-        run: uv run --extra=dev prek run --all-files --hook-stage ${{ matrix.hook-stage }}
-          --verbose
+        uses: j178/prek-action@v3.0.0
+        with:
+          prek-version: 0.4.11
+          extra-args: >-
+            --all-files --hook-stage ${{ matrix.hook-stage }} --verbose
         env:
+          UV_NO_CACHE: '1'
           UV_PYTHON: ${{ matrix.python-version }}
-
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
 
   completion-lint:
     needs: build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,45 +7,6 @@ fail_fast: true
 # See https://pre-commit.com/hooks.html for more hooks
 default_install_hook_types: [pre-commit, pre-push]
 
-ci:
-  # We use system Python, with required dependencies specified in pyproject.toml.
-  # We therefore cannot use those dependencies in pre-commit CI.
-  skip:
-    - actionlint
-    - check-manifest
-    - deptry
-    - doc8
-    - pydocstringformatter
-    - interrogate
-    - interrogate-docs
-    - mypy
-    - mypy-docs
-    - pylint
-    - pylint-docs
-    - pyproject-fmt-fix
-    - pyright
-    - pyright-docs
-    - pyright-verifytypes
-    - ty
-    - ty-docs
-    - pyroma
-    - ruff-check-fix
-    - ruff-check-fix-docs
-    - ruff-format-fix
-    - ruff-format-fix-docs
-    - shellcheck
-    - shellcheck-docs
-    - shfmt
-    - shfmt-docs
-    - sphinx-lint
-    - strict-kwargs-fix
-    - vulture
-    - vulture-docs
-    - yamlfix
-    - pyrefly
-    - pyrefly-docs
-    - zizmor
-
 repos:
   - repo: meta
     hooks:


### PR DESCRIPTION
## Summary

- run the existing lint jobs with `j178/prek-action@v3.0.0` and prek 0.4.11
- add a dedicated autofix.ci producer workflow using `autofix-ci/action@v1.3.4`
- remove legacy pre-commit.ci Lite configuration where present
- let Dependabot update hook revisions through its `pre-commit` ecosystem

Both actions use exact release tags rather than commit SHAs, following the agreed rollout policy.

## Validation

- all changed YAML parses successfully
- `actionlint` passes for both changed workflows
- `zizmor` reports no findings for both changed workflows

Part of [adamtheturtle/Coding-Project-TODOs#8](https://github.com/adamtheturtle/Coding-Project-TODOs/issues/8).

## Before merge

- [ ] Install the autofix.ci GitHub App for this repository
- [ ] Confirm autofix commits are produced on a test pull request
- [ ] Remove the pre-commit.ci GitHub App after the replacement is verified

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI workflows and hook orchestration; no application runtime, auth, or data paths are touched, though autofix.ci requires the GitHub App before auto-commits work.
> 
> **Overview**
> **Replaces pre-commit.ci with prek in Actions and autofix.ci for auto-fix commits.**
> 
> Lint matrix jobs no longer shell out to `uv run prek`; they use `j178/prek-action@v3.0.0` (prek **0.4.11**) with `UV_NO_CACHE` and the same hook-stage matrix. The **pre-commit-ci/lite-action** step is removed.
> 
> A new **`autofix.yml`** workflow runs on PRs and pushes to `main`: checkout, `setup-uv`, prek with `--hook-stage pre-commit --no-fail-fast`, then **`autofix-ci/action@v1.3.4`** (contents read-only until the app is installed).
> 
> **`.pre-commit-config.yaml`** drops the large **`ci:`** skip list that existed for pre-commit.ci. **Dependabot** gains a **`pre-commit`** ecosystem entry for daily hook revision updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c625d960bf703777712e8ec433ee2379f151cfda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->