### PR TITLE
Add no-defaults linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -386,7 +386,7 @@ repos:
           - *uv_version
 
   - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.0
+    rev: v1.0.1
     hooks:
       - id: no-defaults
         stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -261,6 +261,16 @@ repos:
         stages: [pre-commit]
         require_serial: true
 
+      - id: no-defaults
+        name: no-defaults
+        entry: uv run --extra=dev no-defaults
+        language: python
+        types_or: [python]
+        additional_dependencies:
+          - *uv_version
+        stages: [pre-commit]
+        require_serial: true
+
       - id: ruff-check-fix
         name: Ruff check fix
         entry: uv run --extra=dev -m ruff check --fix
@@ -384,9 +394,3 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
-
-  - repo: https://github.com/adamtheturtle/no-defaults
-    rev: v1.0.1
-    hooks:
-      - id: no-defaults
-        stages: [pre-commit]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -384,3 +384,9 @@ repos:
         types_or: [markdown, rst]
         additional_dependencies:
           - *uv_version
+
+  - repo: https://github.com/adamtheturtle/no-defaults
+    rev: v1.0.0
+    hooks:
+      - id: no-defaults
+        stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ lint.per-file-ignores."tests/**/test_*.py" = [
 lint.unfixable = [
     "ERA001",
 ]
+lint.external = [ "NOD" ]
 lint.flake8-pytest-style.parametrize-values-type = "tuple"
 lint.flake8-tidy-imports.banned-api."typing.cast".msg = "typing.cast is banned: use explicit type narrowing or a typed variable instead."
 lint.pydocstyle.convention = "google"
@@ -457,3 +458,7 @@ ignore_path = [
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[tool.no_defaults]
+private_only = true
+per_file_enforcement."tests/**" = "all"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
+    "no-defaults==1.0.1",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pydocstyle==6.3",

--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -34,7 +34,7 @@ def _process_stream(
 def run_command(
     *,
     command: list[str | Path],
-    env: Mapping[str, str] | None = None,
+    env: Mapping[str, str] | None = None,  # noqa: NOD001
     use_pty: bool,
 ) -> subprocess.CompletedProcess[bytes]:
     """Run a command, optionally inside a pseudo-terminal to preserve

--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -28,7 +28,7 @@ CONTENT_SEPARATOR_LEXEME = "content_separator"
 class _CapturedValue:
     """A namespace value isolated to one evaluator call."""
 
-    value: object | None = None
+    value: object | None = None  # noqa: NOD001
 
 
 class _WriterLocal(threading.local):
@@ -345,7 +345,7 @@ def _overwrite_example_content(
     *,
     example: Example,
     new_content: str,
-    encoding: str | None = None,
+    encoding: str | None = None,  # noqa: NOD001
 ) -> None:
     """Update the source document and file with modified example content.
 

--- a/src/sybil_extras/evaluators/shell_evaluator/__init__.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/__init__.py
@@ -85,16 +85,16 @@ class _ShellCommandRunner:
         *,
         args: Sequence[str | Path],
         temp_file_path_maker: TempFilePathMaker,
-        env: Mapping[str, str] | None = None,
-        newline: str | None = None,
+        env: Mapping[str, str] | None = None,  # noqa: NOD001
+        newline: str | None = None,  # noqa: NOD001
         pad_file: bool,
         write_to_file: bool,
         use_pty: bool,
-        encoding: str | None = None,
-        on_modify: _ExampleModified | None = None,
-        namespace_key: str = "",
-        source_preparer: SourcePreparer = NOOP_SOURCE_PREPARER,
-        result_transformer: ResultTransformer = NOOP_RESULT_TRANSFORMER,
+        encoding: str | None = None,  # noqa: NOD001
+        on_modify: _ExampleModified | None = None,  # noqa: NOD001
+        namespace_key: str = "",  # noqa: NOD001
+        source_preparer: SourcePreparer = NOOP_SOURCE_PREPARER,  # noqa: NOD001
+        result_transformer: ResultTransformer = NOOP_RESULT_TRANSFORMER,  # noqa: NOD001
     ) -> None:
         """Initialize the shell command runner.
 

--- a/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
@@ -90,9 +90,9 @@ class _PyconTranscript:
         Returns:
             A parsed transcript.
         """
-        chunks: list[_PyconChunk] = []
-        current_output: list[str] = []
-        current_input: list[str] = []
+        chunks: list[_PyconChunk] = []  # noqa: NOD001
+        current_output: list[str] = []  # noqa: NOD001
+        current_input: list[str] = []  # noqa: NOD001
         seen_prompt = False
 
         for line in pycon_text.splitlines(keepends=True):

--- a/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/_pycon.py
@@ -90,9 +90,9 @@ class _PyconTranscript:
         Returns:
             A parsed transcript.
         """
-        chunks: list[_PyconChunk] = []  # noqa: NOD001
-        current_output: list[str] = []  # noqa: NOD001
-        current_input: list[str] = []  # noqa: NOD001
+        chunks: list[_PyconChunk] = []
+        current_output: list[str] = []
+        current_input: list[str] = []
         seen_prompt = False
 
         for line in pycon_text.splitlines(keepends=True):

--- a/src/sybil_extras/languages.py
+++ b/src/sybil_extras/languages.py
@@ -190,7 +190,7 @@ def _rst_code_block(code: str, language: str) -> str:
 @beartype
 def _html_comment_directive(
     directive: str,
-    argument: str | None = None,
+    argument: str | None = None,  # noqa: NOD001
 ) -> str:
     """Render a directive embedded in an HTML comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -200,7 +200,7 @@ def _html_comment_directive(
 @beartype
 def _percent_comment_directive(
     directive: str,
-    argument: str | None = None,
+    argument: str | None = None,  # noqa: NOD001
 ) -> str:
     """Render a directive embedded in a percent-style comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -210,7 +210,7 @@ def _percent_comment_directive(
 @beartype
 def _rst_directive(
     directive: str,
-    argument: str | None = None,
+    argument: str | None = None,  # noqa: NOD001
 ) -> str:
     """Render a directive for reStructuredText documents."""
     if argument is None:
@@ -221,7 +221,7 @@ def _rst_directive(
 @beartype
 def _jsx_comment_directive(
     directive: str,
-    argument: str | None = None,
+    argument: str | None = None,  # noqa: NOD001
 ) -> str:
     """Render a directive embedded in a JSX comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -231,7 +231,7 @@ def _jsx_comment_directive(
 @beartype
 def _djot_directive(
     directive: str,
-    argument: str | None = None,
+    argument: str | None = None,  # noqa: NOD001
 ) -> str:
     """Render a directive embedded in a djot comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -249,7 +249,7 @@ def _norg_code_block(code: str, language: str) -> str:
 @beartype
 def _norg_directive(
     directive: str,
-    argument: str | None = None,
+    argument: str | None = None,  # noqa: NOD001
 ) -> str:
     """Render a directive embedded in a norg infirm tag."""
     suffix = f": {argument}" if argument is not None else ""
@@ -280,8 +280,8 @@ class _CodeBlockParser(Protocol):
     def __init__(
         self,
         *,
-        language: str | None = None,
-        evaluator: Evaluator | None = None,
+        language: str | None = None,  # noqa: NOD001
+        evaluator: Evaluator | None = None,  # noqa: NOD001
     ) -> None:
         """Construct a code block parser."""
         # We disable a pylint warning here because the ellipsis is required

--- a/tests/evaluators/test_block_accumulator.py
+++ b/tests/evaluators/test_block_accumulator.py
@@ -21,7 +21,7 @@ class _ConcurrencyTrackingNamespace(dict[str, object]):
         self.max_concurrent = 0
         self._lock = threading.Lock()
 
-    def get(self, key: object, default: object = None) -> object:
+    def get(self, key: object, default: object = None) -> object:  # noqa: NOD001
         """Get a value while recording how many reads overlap."""
         with self._lock:
             self._active += 1

--- a/tests/evaluators/test_pycon_shell_evaluator.py
+++ b/tests/evaluators/test_pycon_shell_evaluator.py
@@ -35,9 +35,9 @@ def make_temp_file_path(*, example: Example) -> Path:
 def _make_pycon_evaluator(
     *,
     args: list[str | Path],
-    pad_file: bool = False,
-    write_to_file: bool = False,
-    use_pty: bool = False,
+    pad_file: bool = False,  # noqa: NOD001
+    write_to_file: bool = False,  # noqa: NOD001
+    use_pty: bool = False,  # noqa: NOD001
 ) -> ShellCommandEvaluator:
     """Create an evaluator for pycon code blocks."""
     return ShellCommandEvaluator(


### PR DESCRIPTION
Add `no-defaults` v1.0.0 to the pre-commit/prek configuration.

The policy rejects defaults everywhere in `tests/**` and for private functions, classes, and modules elsewhere. Existing defaults are behavior-preservingly baselined with targeted `# noqa: NOD001` comments where necessary; Ruff is configured to recognize the external `NOD` rule family. Vendored Typeshed is excluded where applicable.

Validated with `prek validate-config`, `prek run no-defaults --all-files`, and Ruff checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and comment-only baselines; no production logic changes beyond lint configuration and noqa annotations.
> 
> **Overview**
> Introduces **`no-defaults` v1.0.1** as a dev dependency and a **pre-commit** hook (alongside `strict-kwargs`), so CI/local runs enforce the policy automatically.
> 
> Policy is configured in **`[tool.no_defaults]`**: **`private_only`** for library code (defaults only allowed on non-private APIs) and **`tests/**` → `all`** (no defaults in tests). Ruff is wired to the external **`NOD`** rule family via **`lint.external`**, so inline **`# noqa: NOD001`** suppressions are recognized.
> 
> Existing defaults that must stay for API compatibility are **baselined** with targeted **`# noqa: NOD001`** on parameters in evaluators, `languages` helpers/protocols, and a few test helpers—no runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d981a3388c055357baefbc63a246ff2dc4da6708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->