### PR TITLE
Collapse the per-parameter suppressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ optional-dependencies.dev = [
     "interrogate==1.7.0",
     "mypy[faster-cache]==2.3.0",
     "mypy-strict-kwargs==2026.7.19.1",
-    "no-defaults==1.0.1",
+    "no-defaults==1.1.0",
     "prek==0.4.11",
     "pydocstringformatter==1.0.0",
     "pydocstyle==6.3",

--- a/src/sybil_extras/evaluators/shell_evaluator/__init__.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/__init__.py
@@ -80,21 +80,21 @@ class _ShellCommandRunner:
     implementation).
     """
 
-    def __init__(
+    def __init__(  # noqa: NOD001
         self,
         *,
         args: Sequence[str | Path],
         temp_file_path_maker: TempFilePathMaker,
-        env: Mapping[str, str] | None = None,  # noqa: NOD001
-        newline: str | None = None,  # noqa: NOD001
+        env: Mapping[str, str] | None = None,
+        newline: str | None = None,
         pad_file: bool,
         write_to_file: bool,
         use_pty: bool,
-        encoding: str | None = None,  # noqa: NOD001
-        on_modify: _ExampleModified | None = None,  # noqa: NOD001
-        namespace_key: str = "",  # noqa: NOD001
-        source_preparer: SourcePreparer = NOOP_SOURCE_PREPARER,  # noqa: NOD001
-        result_transformer: ResultTransformer = NOOP_RESULT_TRANSFORMER,  # noqa: NOD001
+        encoding: str | None = None,
+        on_modify: _ExampleModified | None = None,
+        namespace_key: str = "",
+        source_preparer: SourcePreparer = NOOP_SOURCE_PREPARER,
+        result_transformer: ResultTransformer = NOOP_RESULT_TRANSFORMER,
     ) -> None:
         """Initialize the shell command runner.
 

--- a/src/sybil_extras/languages.py
+++ b/src/sybil_extras/languages.py
@@ -277,11 +277,11 @@ def _rst_jinja_block(body: str) -> str:
 class _CodeBlockParser(Protocol):
     """A parser for code blocks."""
 
-    def __init__(
+    def __init__(  # noqa: NOD001
         self,
         *,
-        language: str | None = None,  # noqa: NOD001
-        evaluator: Evaluator | None = None,  # noqa: NOD001
+        language: str | None = None,
+        evaluator: Evaluator | None = None,
     ) -> None:
         """Construct a code block parser."""
         # We disable a pylint warning here because the ellipsis is required


### PR DESCRIPTION
Bumps `no-defaults` to 1.1.0 and collapses the per-parameter `NOD001` directives.

Since 1.1.0 a directive on the `def` line covers every parameter of that signature, so a wide signature needs one directive rather than one per parameter.

**19 → 12.** The shell evaluator constructor drops from 7 directives to 1, and languages.py from 2 to 1. The other 12 are lone parameters on separate functions, which cannot collapse further.

The defaults themselves are unchanged — these are public API signatures, where removing a default is a breaking change for callers. This is purely about how the suppressions are written. Comment-only apart from the version pin; ruff clean and the test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only and dev-dependency pin changes with no runtime or API behavior changes.
> 
> **Overview**
> Upgrades the dev dependency **`no-defaults`** from **1.0.1** to **1.1.0**, which lets a single `# noqa: NOD001` on the **`def`** line cover every parameter in that signature.
> 
> **`_ShellCommandRunner.__init__`** and the **`_CodeBlockParser`** protocol **`__init__`** drop per-parameter **`NOD001`** comments in favor of one directive on the definition line. Parameter defaults and public API shapes are unchanged; this is only how lint suppressions are written.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e569455253cb7138484d8ad09fbdf51f55a8d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->