### PR TITLE
Remove the remaining defaults instead of suppressing them

### DIFF
--- a/src/sybil_extras/evaluators/_subprocess_utils.py
+++ b/src/sybil_extras/evaluators/_subprocess_utils.py
@@ -34,7 +34,7 @@ def _process_stream(
 def run_command(
     *,
     command: list[str | Path],
-    env: Mapping[str, str] | None = None,  # noqa: NOD001
+    env: Mapping[str, str] | None,
     use_pty: bool,
 ) -> subprocess.CompletedProcess[bytes]:
     """Run a command, optionally inside a pseudo-terminal to preserve

--- a/src/sybil_extras/evaluators/code_block_writer.py
+++ b/src/sybil_extras/evaluators/code_block_writer.py
@@ -28,7 +28,7 @@ CONTENT_SEPARATOR_LEXEME = "content_separator"
 class _CapturedValue:
     """A namespace value isolated to one evaluator call."""
 
-    value: object | None = None  # noqa: NOD001
+    value: object | None
 
 
 class _WriterLocal(threading.local):
@@ -345,7 +345,7 @@ def _overwrite_example_content(
     *,
     example: Example,
     new_content: str,
-    encoding: str | None = None,  # noqa: NOD001
+    encoding: str | None,
 ) -> None:
     """Update the source document and file with modified example content.
 

--- a/src/sybil_extras/evaluators/shell_evaluator/__init__.py
+++ b/src/sybil_extras/evaluators/shell_evaluator/__init__.py
@@ -80,21 +80,21 @@ class _ShellCommandRunner:
     implementation).
     """
 
-    def __init__(  # noqa: NOD001
+    def __init__(
         self,
         *,
         args: Sequence[str | Path],
         temp_file_path_maker: TempFilePathMaker,
-        env: Mapping[str, str] | None = None,
-        newline: str | None = None,
+        env: Mapping[str, str] | None,
+        newline: str | None,
         pad_file: bool,
         write_to_file: bool,
         use_pty: bool,
-        encoding: str | None = None,
-        on_modify: _ExampleModified | None = None,
-        namespace_key: str = "",
-        source_preparer: SourcePreparer = NOOP_SOURCE_PREPARER,
-        result_transformer: ResultTransformer = NOOP_RESULT_TRANSFORMER,
+        encoding: str | None,
+        on_modify: _ExampleModified | None,
+        namespace_key: str,
+        source_preparer: SourcePreparer,
+        result_transformer: ResultTransformer,
     ) -> None:
         """Initialize the shell command runner.
 

--- a/src/sybil_extras/languages.py
+++ b/src/sybil_extras/languages.py
@@ -147,7 +147,7 @@ class CodeBlockBuilder(Protocol):
 class DirectiveBuilder(Protocol):
     """A callable that renders directives for a markup language."""
 
-    def __call__(self, directive: str, argument: str | None = None) -> str:
+    def __call__(self, directive: str, argument: str | None) -> str:
         """Render ``directive`` with the optional ``argument``."""
         ...  # pylint: disable=unnecessary-ellipsis
 
@@ -190,7 +190,7 @@ def _rst_code_block(code: str, language: str) -> str:
 @beartype
 def _html_comment_directive(
     directive: str,
-    argument: str | None = None,  # noqa: NOD001
+    argument: str | None,
 ) -> str:
     """Render a directive embedded in an HTML comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -200,7 +200,7 @@ def _html_comment_directive(
 @beartype
 def _percent_comment_directive(
     directive: str,
-    argument: str | None = None,  # noqa: NOD001
+    argument: str | None,
 ) -> str:
     """Render a directive embedded in a percent-style comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -210,7 +210,7 @@ def _percent_comment_directive(
 @beartype
 def _rst_directive(
     directive: str,
-    argument: str | None = None,  # noqa: NOD001
+    argument: str | None,
 ) -> str:
     """Render a directive for reStructuredText documents."""
     if argument is None:
@@ -221,7 +221,7 @@ def _rst_directive(
 @beartype
 def _jsx_comment_directive(
     directive: str,
-    argument: str | None = None,  # noqa: NOD001
+    argument: str | None,
 ) -> str:
     """Render a directive embedded in a JSX comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -231,7 +231,7 @@ def _jsx_comment_directive(
 @beartype
 def _djot_directive(
     directive: str,
-    argument: str | None = None,  # noqa: NOD001
+    argument: str | None,
 ) -> str:
     """Render a directive embedded in a djot comment."""
     suffix = f": {argument}" if argument is not None else ""
@@ -249,7 +249,7 @@ def _norg_code_block(code: str, language: str) -> str:
 @beartype
 def _norg_directive(
     directive: str,
-    argument: str | None = None,  # noqa: NOD001
+    argument: str | None,
 ) -> str:
     """Render a directive embedded in a norg infirm tag."""
     suffix = f": {argument}" if argument is not None else ""
@@ -277,11 +277,11 @@ def _rst_jinja_block(body: str) -> str:
 class _CodeBlockParser(Protocol):
     """A parser for code blocks."""
 
-    def __init__(  # noqa: NOD001
+    def __init__(
         self,
         *,
-        language: str | None = None,
-        evaluator: Evaluator | None = None,
+        language: str | None,
+        evaluator: Evaluator | None,
     ) -> None:
         """Construct a code block parser."""
         # We disable a pylint warning here because the ellipsis is required

--- a/tests/parsers/djot/test_codeblock.py
+++ b/tests/parsers/djot/test_codeblock.py
@@ -11,7 +11,7 @@ from sybil_extras.parsers.djot.codeblock import DjotRawFencedCodeBlockLexer
 
 def _parse(text: str) -> list[Region]:
     """Parse the supplied Djot text for Python code blocks."""
-    parser = DJOT.code_block_parser_cls(language="python")
+    parser = DJOT.code_block_parser_cls(language="python", evaluator=None)
     document = Document(text=text, path="doc.djot")
     return list(parser(document=document))
 

--- a/tests/parsers/norg/test_codeblock.py
+++ b/tests/parsers/norg/test_codeblock.py
@@ -9,7 +9,7 @@ from sybil_extras.languages import NORG
 
 def _parse(text: str) -> list[Region]:
     """Parse the supplied Norg text for Python code blocks."""
-    parser = NORG.code_block_parser_cls(language="python")
+    parser = NORG.code_block_parser_cls(language="python", evaluator=None)
     document = Document(text=text, path="doc.norg")
     return list(parser(document=document))
 

--- a/tests/parsers/test_group_all.py
+++ b/tests/parsers/test_group_all.py
@@ -495,7 +495,9 @@ def test_state_cleanup_on_evaluator_failure(
         evaluator=shell_evaluator,
         pad_groups=False,
     )
-    code_block_parser = language.code_block_parser_cls(language="bash")
+    code_block_parser = language.code_block_parser_cls(
+        language="bash", evaluator=None
+    )
 
     sybil = Sybil(parsers=[code_block_parser, group_all_parser])
     document = sybil.parse(path=test_document)

--- a/tests/parsers/test_grouped_source.py
+++ b/tests/parsers/test_grouped_source.py
@@ -330,7 +330,7 @@ def test_no_argument(
     language, directive_builder = language_directive_builder
     content = language.markup_separator.join(
         [
-            directive_builder(directive="group"),
+            directive_builder(directive="group", argument=None),
             directive_builder(directive="group", argument="end"),
         ]
     )
@@ -609,7 +609,9 @@ def test_with_shell_command_evaluator(
         evaluator=shell_evaluator,
         pad_groups=True,
     )
-    code_block_parser = language.code_block_parser_cls(language="python")
+    code_block_parser = language.code_block_parser_cls(
+        language="python", evaluator=None
+    )
 
     sybil = Sybil(parsers=[code_block_parser, group_parser])
     document = sybil.parse(path=test_document)
@@ -680,7 +682,9 @@ def test_state_cleanup_on_evaluator_failure(
         evaluator=shell_evaluator,
         pad_groups=False,
     )
-    code_block_parser = language.code_block_parser_cls(language="bash")
+    code_block_parser = language.code_block_parser_cls(
+        language="bash", evaluator=None
+    )
 
     sybil = Sybil(parsers=[code_block_parser, group_parser])
     document = sybil.parse(path=test_document)
@@ -976,7 +980,9 @@ def test_no_pad_groups(
         evaluator=shell_evaluator,
         pad_groups=False,
     )
-    code_block_parser = language.code_block_parser_cls(language="python")
+    code_block_parser = language.code_block_parser_cls(
+        language="python", evaluator=None
+    )
 
     sybil = Sybil(parsers=[code_block_parser, group_parser])
     document = sybil.parse(path=test_document)

--- a/tests/test_languages.py
+++ b/tests/test_languages.py
@@ -250,7 +250,7 @@ def test_mdx_info_line_at_eof_without_newline() -> None:
     An MDX code block info line at EOF without trailing newline is
     recognized.
     """
-    parser = MDX.code_block_parser_cls(language="python")
+    parser = MDX.code_block_parser_cls(language="python", evaluator=None)
     document = Document(text="```python", path="doc.mdx")
     regions = list(parser(document=document))
 
@@ -263,7 +263,7 @@ def test_mdx_info_line_with_attributes_at_eof_without_newline() -> None:
     An MDX code block with attributes at EOF without trailing newline is
     recognized.
     """
-    parser = MDX.code_block_parser_cls(language="python")
+    parser = MDX.code_block_parser_cls(language="python", evaluator=None)
     document = Document(text='```python title="example.py"', path="doc.mdx")
     regions = list(parser(document=document))
 


### PR DESCRIPTION
Removes 18 of the 19 `NOD001` suppressions by removing the defaults for real.

### The protocols had to change too

The directive builders and the code block parsers could not drop their defaults on their own: `DirectiveBuilder.__call__` declared `argument` optional, and `_CodeBlockParser.__init__` declared `language` and `evaluator` optional. An implementation must be at least as permissive as its protocol, so both protocols lose their defaults as well.

That direction is safe and strictly more permissive for third parties — an implementation that keeps its own defaults still satisfies a protocol declared without them.

### The one that stays

`_ConcurrencyTrackingNamespace.get` in `tests/evaluators/test_block_accumulator.py` mimics `dict.get`, whose second argument is optional in the stdlib signature it imitates. That default is part of the interface rather than a style choice, and it keeps its suppression with a comment saying so.

**19 → 1.** mypy clean, ruff clean, 971 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical signature and test call-site updates with no intended behavior change; slightly stricter typing for implementers of the affected protocols.
> 
> **Overview**
> Removes **default values** from several internal APIs and protocol signatures so the codebase complies with **NOD001** without `noqa` suppressions (18 of 19 removed).
> 
> **Protocols and helpers** no longer declare defaults on optional parameters: `DirectiveBuilder`, `_CodeBlockParser`, directive renderers in `languages.py`, `run_command`’s `env`, `_ShellCommandRunner.__init__`, `_CapturedValue.value`, and `_overwrite_example_content`’s `encoding`. Callers must pass these arguments explicitly (including `None` where optional).
> 
> **Tests** are updated accordingly—e.g. `code_block_parser_cls(..., evaluator=None)` and `directive_builder(directive="group", argument=None)` for the “no argument” group case.
> 
> Public facades like **`ShellCommandEvaluator`** still expose defaults at the user-facing layer; only the stricter internal/protocol surfaces changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0ab5f8f06b95264affe45ed89a9f6c7f643b11c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->