### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dynamic = [
     "version",
 ]
 dependencies = [
-    "beartype>=0.22.9",
+    "beartype==0.23.0rc0",
     "markdown-it-py>=3.0.0",
     "myst-parser>=5.0.0",
     "sybil>=9.3.0",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change with no application code edits; risk is limited to possible runtime/type-checking behavior differences from the new beartype RC.
> 
> **Overview**
> Pins the runtime dependency **`beartype`** from **`>=0.22.9`** to **`==0.23.0rc0`** in `pyproject.toml` so CI and local installs exercise the **0.23.0** release candidate against this repo’s tests (including **`pytest-beartype-tests`**).
> 
> This is a **temporary, exact pin** for RC evaluation; the PR is **not meant to merge as-is**—the constraint should be relaxed (e.g. back to a minimum version) once the RC is validated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a6e54ec98f03bc9161269cf386f3302e0bc0c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->