### PR TITLE
Bump August dependency releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ optional-dependencies.dev = [
     "pyright==1.1.411",
     "pyroma==5.0.1",
     "pytest==9.1.1",
-    "pytest-beartype-tests==2026.4.26",
+    "pytest-beartype-tests==2026.8.16",
     "pytest-cov==7.1.0",
     "ruff==0.16.2",
     # We add shellcheck-py not only for shell scripts and shell code blocks,


### PR DESCRIPTION
Updates the newly released internal dependencies to their latest August 2026 versions.\n\nThis keeps the development and test toolchain on the released implementations and refreshes the uv lockfile.\n\nValidation: `uv lock` completed successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single dev/test toolchain version bump with no production dependency or runtime behavior changes.
> 
> **Overview**
> Bumps the dev-only **`pytest-beartype-tests`** pin in `pyproject.toml` from `2026.4.26` to **`2026.8.16`**, aligning the beartype-related pytest plugin with the August 2026 internal release line described in the PR.
> 
> No application or runtime dependencies change; this only affects the optional `dev` extra used for local/CI testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c48c1e8b4d73d1dad96d60a5c6182849c3ad13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->